### PR TITLE
Avoid race conditions in tests

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -42,6 +42,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mock-server</groupId>
       <artifactId>mockserver-netty</artifactId>
       <version>5.11.2</version>

--- a/deployment/src/test/java/io/quarkiverse/logging/splunk/AbstractMockServerTest.java
+++ b/deployment/src/test/java/io/quarkiverse/logging/splunk/AbstractMockServerTest.java
@@ -1,0 +1,45 @@
+package io.quarkiverse.logging.splunk;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.ClearType;
+
+public abstract class AbstractMockServerTest {
+
+    static ClientAndServer httpServer;
+
+    @BeforeAll
+    public static void setUpOnce() {
+        httpServer = ClientAndServer.startClientAndServer(8088);
+        // This needs to be done as early as possible, so Quarkus startup logs don't fail to be sent
+        httpServer
+                .when(request().withPath("/services/collector/event/1.0"))
+                .respond(response().withStatusCode(200).withBody("{}"));
+        httpServer.when(request()).respond(response().withStatusCode(400));
+    }
+
+    @AfterAll
+    public static void tearDownOnce() {
+        httpServer.stop();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        httpServer.clear(request(), ClearType.LOG);
+    }
+
+    /**
+     * Splunk client uses an asynchronous HTTP queue, so to avoid race conditions we need to wait for mockserver to receive the
+     * call.
+     */
+    protected void awaitMockServer() {
+        await().atMost(1, SECONDS).until(() -> httpServer.retrieveRecordedRequests(request()).length != 0);
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/logging/splunk/LoggingSplunkMinimalConfigTest.java
+++ b/deployment/src/test/java/io/quarkiverse/logging/splunk/LoggingSplunkMinimalConfigTest.java
@@ -5,24 +5,18 @@ Contributor(s): Kevin Viet, Romain Quinio (Amadeus s.a.s.)
 package io.quarkiverse.logging.splunk;
 
 import static org.mockserver.model.HttpRequest.request;
-import static org.mockserver.model.HttpResponse.response;
 import static org.mockserver.model.JsonBody.json;
 import static org.mockserver.model.Not.not;
 
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.mockserver.integration.ClientAndServer;
-import org.mockserver.model.ClearType;
 
 import io.quarkus.test.QuarkusUnitTest;
 
-class LoggingSplunkMinimalConfigTest {
+class LoggingSplunkMinimalConfigTest extends AbstractMockServerTest {
 
     @RegisterExtension
     static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
@@ -30,39 +24,19 @@ class LoggingSplunkMinimalConfigTest {
             .withConfigurationResource("mock-server.properties")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
 
-    static ClientAndServer httpServer;
-
     static final Logger logger = Logger.getLogger(LoggingSplunkMinimalConfigTest.class);
-
-    @BeforeAll
-    public static void setUpOnce() {
-        httpServer = ClientAndServer.startClientAndServer(8088);
-        // This needs to be done as early as possible, so Quarkus startup logs don't fail to be sent
-        httpServer
-                .when(request().withPath("/services/collector/event/1.0"))
-                .respond(response().withStatusCode(200).withBody("{}"));
-        httpServer.when(request()).respond(response().withStatusCode(400));
-    }
-
-    @AfterAll
-    public static void tearDownOnce() {
-        httpServer.stop();
-    }
-
-    @AfterEach
-    public void tearDown() {
-        httpServer.clear(request(), ClearType.LOG);
-    }
 
     @Test
     void indexIsNotSentIfUnspecified() {
         logger.info("hello splunk");
+        awaitMockServer();
         httpServer.verify(request().withBody(not(json("{ index: ''}"))));
     }
 
     @Test
     void sourceTypeDefaultsToJson() {
         logger.info("hello splunk");
+        awaitMockServer();
         httpServer.verify(request().withBody(json("{ sourcetype: '_json'}")));
     }
 }

--- a/deployment/src/test/java/io/quarkiverse/logging/splunk/LoggingSplunkSendErrorTest.java
+++ b/deployment/src/test/java/io/quarkiverse/logging/splunk/LoggingSplunkSendErrorTest.java
@@ -4,6 +4,8 @@ Contributor(s): Kevin Viet, Romain Quinio (Amadeus s.a.s.)
  */
 package io.quarkiverse.logging.splunk;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 import static org.mockserver.model.JsonBody.json;
@@ -14,7 +16,6 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockserver.integration.ClientAndServer;
@@ -53,9 +54,9 @@ class LoggingSplunkSendErrorTest {
     }
 
     @Test
-    @Disabled("The test is flaky in github CI")
     void testSendError() {
         logger.info("error splunk");
+        await().atMost(1, SECONDS).until(() -> httpServer.retrieveRecordedRequests(request()).length != 0);
         // The retries-on-error is not applicable in case of HTTP error
         httpServer.verify(request().withBody(json("{ event: { message:'error splunk'} }")),
                 VerificationTimes.exactly(1));

--- a/deployment/src/test/java/io/quarkiverse/logging/splunk/LoggingSplunkWithMetadataTest.java
+++ b/deployment/src/test/java/io/quarkiverse/logging/splunk/LoggingSplunkWithMetadataTest.java
@@ -5,24 +5,18 @@ Contributor(s): Kevin Viet, Romain Quinio (Amadeus s.a.s.)
 package io.quarkiverse.logging.splunk;
 
 import static org.mockserver.model.HttpRequest.request;
-import static org.mockserver.model.HttpResponse.response;
 import static org.mockserver.model.JsonBody.json;
 import static org.mockserver.model.RegexBody.regex;
 
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.mockserver.integration.ClientAndServer;
-import org.mockserver.model.ClearType;
 
 import io.quarkus.test.QuarkusUnitTest;
 
-class LoggingSplunkWithMetadataTest {
+class LoggingSplunkWithMetadataTest extends AbstractMockServerTest {
 
     @RegisterExtension
     static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
@@ -30,33 +24,12 @@ class LoggingSplunkWithMetadataTest {
             .withConfigurationResource("mock-server.properties")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
 
-    static ClientAndServer httpServer;
-
     static final Logger logger = Logger.getLogger(LoggingSplunkWithMetadataTest.class);
-
-    @BeforeAll
-    public static void setUpOnce() {
-        httpServer = ClientAndServer.startClientAndServer(8088);
-        // This needs to be done as early as possible, so Quarkus startup logs don't fail to be sent
-        httpServer
-                .when(request().withPath("/services/collector/event/1.0"))
-                .respond(response().withStatusCode(200).withBody("{}"));
-        httpServer.when(request()).respond(response().withStatusCode(400));
-    }
-
-    @AfterAll
-    public static void tearDownOnce() {
-        httpServer.stop();
-    }
-
-    @AfterEach
-    public void tearDown() {
-        httpServer.clear(request(), ClearType.LOG);
-    }
 
     @Test
     void clientAddsStructuredMetadata() {
         logger.error("hello splunk", new RuntimeException("test exception"));
+        awaitMockServer();
         httpServer.verify(request().withBody(json(
                 "{ event: { message: 'hello splunk', " +
                         "logger:'io.quarkiverse.logging.splunk.LoggingSplunkWithMetadataTest', " +


### PR DESCRIPTION
Splunk client uses an asynchronous HTTP queue, so we need to wait for mockserver to receive the call before trying to assert (was pretty rare in local, but happens more frequently in Github CI)

Create an abstract class for the mock-server lifecycle.