### PR TITLE
Bump quarkus minor version to 1.13.2.Final

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -4,8 +4,7 @@
   <parent>
     <groupId>io.quarkiverse.logging.splunk</groupId>
     <artifactId>quarkus-logging-splunk-parent</artifactId>
-    <version>1.1.0-SNAPSHOT
-    </version>
+    <version>2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/deployment/src/test/java/io/quarkiverse/logging/splunk/LoggingSplunkDisabledTest.java
+++ b/deployment/src/test/java/io/quarkiverse/logging/splunk/LoggingSplunkDisabledTest.java
@@ -12,7 +12,7 @@ import java.util.Arrays;
 import java.util.logging.Handler;
 import java.util.logging.Logger;
 
-import org.jboss.logmanager.handlers.DelayedHandler;
+import org.jboss.logmanager.ExtHandler;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
@@ -30,7 +30,7 @@ class LoggingSplunkDisabledTest {
 
     @Test
     void extensionDisabled() {
-        DelayedHandler delayedHandler = InitialConfigurator.DELAYED_HANDLER;
+        ExtHandler delayedHandler = InitialConfigurator.DELAYED_HANDLER;
         assertThat(Logger.getLogger("").getHandlers(), hasItemInArray(delayedHandler));
         Handler handler = Arrays.stream(delayedHandler.getHandlers())
                 .filter(h -> (h instanceof SplunkLogHandler))

--- a/deployment/src/test/java/io/quarkiverse/logging/splunk/LoggingSplunkTest.java
+++ b/deployment/src/test/java/io/quarkiverse/logging/splunk/LoggingSplunkTest.java
@@ -15,7 +15,7 @@ import java.util.logging.Handler;
 import java.util.logging.Logger;
 
 import org.jboss.logging.MDC;
-import org.jboss.logmanager.handlers.DelayedHandler;
+import org.jboss.logmanager.ExtHandler;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
@@ -37,7 +37,7 @@ class LoggingSplunkTest extends AbstractMockServerTest {
 
     @Test
     void handlerShouldBeCreated() {
-        DelayedHandler delayedHandler = InitialConfigurator.DELAYED_HANDLER;
+        ExtHandler delayedHandler = InitialConfigurator.DELAYED_HANDLER;
         assertThat(Logger.getLogger("").getHandlers(), hasItemInArray(delayedHandler));
         Handler handler = Arrays.stream(delayedHandler.getHandlers())
                 .filter(h -> (h instanceof SplunkLogHandler))

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkiverse.logging.splunk</groupId>
     <artifactId>quarkus-logging-splunk-parent</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.quarkiverse.logging.splunk</groupId>
     <artifactId>quarkus-logging-splunk-parent</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>io.quarkiverse.logging.splunk</groupId>
   <artifactId>quarkus-logging-splunk-parent</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>2.0-SNAPSHOT</version>
   <name>Splunk logging extension - Parent</name>
 
   <packaging>pom</packaging>
@@ -41,7 +41,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.parameters>true</maven.compiler.parameters>
-    <quarkus.version>1.11.5.Final</quarkus.version>
+    <quarkus.version>1.13.2.Final</quarkus.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <splunk.logging.version>1.8.0</splunk.logging.version>
     <testcontainers.version>1.15.3</testcontainers.version>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkiverse.logging.splunk</groupId>
     <artifactId>quarkus-logging-splunk-parent</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkErrorCallback.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkErrorCallback.java
@@ -12,8 +12,8 @@ import java.util.List;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 
+import org.jboss.logmanager.ExtHandler;
 import org.jboss.logmanager.handlers.ConsoleHandler;
-import org.jboss.logmanager.handlers.DelayedHandler;
 
 import com.splunk.logging.HttpEventCollectorErrorHandler.ErrorCallback;
 import com.splunk.logging.HttpEventCollectorEventInfo;
@@ -65,7 +65,7 @@ class SplunkErrorCallback implements ErrorCallback {
      */
     private boolean isConsoleHandlerEnabled() {
         if (consoleEnabled == null) {
-            DelayedHandler delayedHandler = InitialConfigurator.DELAYED_HANDLER;
+            ExtHandler delayedHandler = InitialConfigurator.DELAYED_HANDLER;
             Handler consoleHandler = Arrays.stream(delayedHandler.getHandlers())
                     .filter(h -> (h instanceof ConsoleHandler))
                     .findFirst().orElse(null);


### PR DESCRIPTION
There's a new minor version of Quarkus in town.
This version has broken the extension build because of a minor issue, however we need to bump the extension to 2.x in order to support our RedHat Build or Quarkus branch (rhbq/1.11).

- Switch quarkus-logging-splunk to 2.0
- Fix DelayedHandler class cast issue