### PR TITLE
Work around an issue in the quarkus-bom to get CI green

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,11 @@
         <artifactId>hamcrest-library</artifactId>
         <version>2.2</version>
       </dependency>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-core</artifactId>
+        <version>2.2</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <build>


### PR DESCRIPTION
We have an issue in the quarkus-bom right now (in the `main` branch only) and this breaks Ecosystem CI. I'm
not entirely sure how much time it will take us to fix it given it's a
complex multi-projects one and, given the workaround is simple, I
thought it would be a good idea to apply it and get CI green.