### PR TITLE
Re-try release 2.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,5 +1,5 @@
 name: Quarkiverse Extension
 release:
-  current-version: 2.0.0
+  current-version: 2.0.1
   next-version: 2.1.0-SNAPSHOT
 


### PR DESCRIPTION
Something went wrong during https://github.com/quarkiverse/quarkus-logging-splunk/pull/17/, let's re-try.
I didn't see any "re-run" from Github actions UI, probably because it triggers on a PR closure.