### PR TITLE
Bump splunk-library-javalogging from 1.9.0 to 1.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <quarkus.version>2.0.3.Final</quarkus.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
-    <splunk.logging.version>1.9.0</splunk.logging.version>
+    <splunk.logging.version>1.10.0</splunk.logging.version>
     <testcontainers.version>1.15.3</testcontainers.version>
 
     <!-- https://antoniogoncalves.org/2012/12/13/lets-turn-integration-tests-with-maven-to-a-first-class-citizen/ -->

--- a/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkLogHandler.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkLogHandler.java
@@ -47,6 +47,7 @@ public class SplunkLogHandler extends ExtHandler {
             return;
         }
         this.sender.send(
+                record.getMillis(),
                 record.getLevel().toString(),
                 formatted,
                 includeLoggerName ? record.getLoggerName() : null,

--- a/runtime/src/test/java/io/quarkiverse/logging/splunk/SplunkErrorCallbackTest.java
+++ b/runtime/src/test/java/io/quarkiverse/logging/splunk/SplunkErrorCallbackTest.java
@@ -39,7 +39,7 @@ public class SplunkErrorCallbackTest {
     @Spy
     PrintStream stderr = new PrintStream(errContent);
 
-    HttpEventCollectorEventInfo logEvent = new HttpEventCollectorEventInfo("INFO", "Hello",
+    HttpEventCollectorEventInfo logEvent = new HttpEventCollectorEventInfo(System.currentTimeMillis(), "INFO", "Hello",
             SplunkErrorCallbackTest.class.getName(), "thread", null, null, null);
 
     @AfterEach

--- a/runtime/src/test/java/io/quarkiverse/logging/splunk/SplunkLogHandlerTest.java
+++ b/runtime/src/test/java/io/quarkiverse/logging/splunk/SplunkLogHandlerTest.java
@@ -4,6 +4,7 @@ Contributor(s): Kevin Viet, Romain Quinio (Amadeus s.a.s.)
  */
 package io.quarkiverse.logging.splunk;
 
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -51,7 +52,8 @@ class SplunkLogHandlerTest {
         handler.publish(record);
 
         verify(formatter).format(eq(record));
-        verify(sender).send(eq(record.getLevel().toString()),
+        verify(sender).send(anyLong(),
+                eq(record.getLevel().toString()),
                 eq("Hello world"),
                 eq(record.getLoggerName()),
                 eq("1"),
@@ -71,7 +73,8 @@ class SplunkLogHandlerTest {
 
         handler.publish(record);
 
-        verify(sender).send(eq(record.getLevel().toString()),
+        verify(sender).send(anyLong(),
+                eq(record.getLevel().toString()),
                 eq(record.getMessage()),
                 eq(record.getLoggerName()),
                 eq("1"),


### PR DESCRIPTION
- Solve breaking changes in #43
- Use new API to propagate the original log event timestamp into Splunk event metadata