### PR TITLE
Release 2.1

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,5 +1,5 @@
 name: Quarkiverse Extension
 release:
-  current-version: 2.0.0
-  next-version: 2.1.0-SNAPSHOT
+  current-version: 2.1.0
+  next-version: 2.2.0-SNAPSHOT
 


### PR DESCRIPTION
There was no breaking changes on Quarkus side, so can be considered a minor.
Can be used as basis for the RHBQ 2.2 branch of the extension