### PR TITLE
Add Maven description, as used by code.quarkus.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
-A quarkus Extension to send logs to a Splunk Http Event Collector (HEC).
+A Quarkus extension to send logs to a Splunk HTTP Event Collector (HEC).
 
 To get started, add the dependency:
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
   <artifactId>quarkus-logging-splunk-parent</artifactId>
   <version>2.2.0-SNAPSHOT</version>
   <name>Splunk logging extension - Parent</name>
+  <description>Send logs to a Splunk HTTP Event Collector (HEC)</description>
 
   <packaging>pom</packaging>
 


### PR DESCRIPTION
The Quarkiverse extensions are now listed on code.quarkus.io (https://code.quarkus.io/?e=io.quarkiverse.logging.splunk%3Aquarkus-logging-splunk&extension-search=origin:other%20splunk ), but the current description is inherited from parent pom.