### PR TITLE
Align with quarkiverse-parent 9

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -11,11 +11,6 @@
   <artifactId>quarkus-logging-splunk-docs</artifactId>
   <name>Splunk logging extension - Documentation</name>
 
-  <properties>
-    <asciidoctorj.version>2.5.2</asciidoctorj.version>
-    <asciidoctor-maven-plugin.version>2.2.1</asciidoctor-maven-plugin.version>
-  </properties>
-
   <dependencies>
     <!-- Make sure the doc is built after the other artifacts -->
     <dependency>
@@ -30,56 +25,6 @@
       <plugin>
         <groupId>org.asciidoctor</groupId>
         <artifactId>asciidoctor-maven-plugin</artifactId>
-        <version>${asciidoctor-maven-plugin.version}</version>
-        <configuration>
-          <skip>${skipDocs}</skip>
-          <enableVerbose>true</enableVerbose>
-          <logHandler>
-            <failIf>
-              <severity>WARN</severity>
-            </failIf>
-          </logHandler>
-          <sourceDirectory>${project.basedir}/modules/ROOT/pages/</sourceDirectory>
-          <preserveDirectories>true</preserveDirectories>
-          <attributes>
-            <icons>font</icons>
-            <!-- Antora images path -->
-            <imagesdir>./_images/</imagesdir>
-            <sectanchors>true</sectanchors>
-            <!-- set the idprefix to blank -->
-            <idprefix />
-            <idseparator>-</idseparator>
-            <docinfo1>true</docinfo1>
-            <!-- avoid content security policy violations -->
-            <skip-front-matter>true</skip-front-matter>
-          </attributes>
-        </configuration>
-        <executions>
-          <execution>
-            <id>output-html</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>process-asciidoc</goal>
-            </goals>
-            <configuration>
-              <skip>${skipDocs}</skip>
-              <backend>html5</backend>
-              <attributes>
-                <source-highlighter>coderay</source-highlighter>
-                <!-- avoid content security policy violations -->
-                <linkcss>true</linkcss>
-                <copycss>true</copycss>
-              </attributes>
-            </configuration>
-          </execution>
-        </executions>
-        <dependencies>
-          <dependency>
-            <groupId>org.asciidoctor</groupId>
-            <artifactId>asciidoctorj</artifactId>
-            <version>${asciidoctorj.version}</version>
-          </dependency>
-        </dependencies>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
       <groupId>io.quarkiverse</groupId>
       <artifactId>quarkiverse-parent</artifactId>
-      <version>8</version>
+      <version>9</version>
     </parent>
 
   <groupId>io.quarkiverse.logging.splunk</groupId>
@@ -39,8 +39,9 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.release>11</maven.compiler.release>
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <quarkus.version>2.2.3.Final</quarkus.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>


### PR DESCRIPTION
Replaces #68 

- Compile to Java 11 bytecode (Quarkus 2+)
- Let quarkiverse-parent manage asciidoctor versions

