### PR TITLE
Add support for additional/custom splunk event metadata fields

### DIFF
--- a/deployment/src/test/java/io/quarkiverse/logging/splunk/LoggingSplunkWithMetadataTest.java
+++ b/deployment/src/test/java/io/quarkiverse/logging/splunk/LoggingSplunkWithMetadataTest.java
@@ -36,4 +36,18 @@ class LoggingSplunkWithMetadataTest extends AbstractMockServerTest {
                         "exception: 'test exception' }}"))
                 .withBody(regex(".*thread.*")));
     }
+
+    @Test
+    void clientAddsAdditionalMetadataFields() {
+        logger.info("hello splunk");
+        awaitMockServer();
+        httpServer.verify(request().withBody(
+                json(
+                        "{ fields: { "
+                                + "additional-field-0: 'important-information', "
+                                + "additional-field-1: 'less-important-information'"
+                                + "}"
+                                + "}")));
+    }
+
 }

--- a/deployment/src/test/resources/application-splunk-logging-with-metadata.properties
+++ b/deployment/src/test/resources/application-splunk-logging-with-metadata.properties
@@ -3,3 +3,5 @@ quarkus.log.handler.splunk.token=12345678-1234-1234-1234-1234567890AB
 quarkus.log.handler.splunk.include-exception=true
 quarkus.log.handler.splunk.include-logger-name=true
 quarkus.log.handler.splunk.include-thread-name=true
+quarkus.log.handler.splunk.metadata-fields.additional-field-0=important-information
+quarkus.log.handler.splunk.metadata-fields.additional-field-1=less-important-information

--- a/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkConfig.java
@@ -5,6 +5,8 @@ Contributor(s): Kevin Viet, Romain Quinio (Amadeus s.a.s.)
 package io.quarkiverse.logging.splunk;
 
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.logging.Level;
 
@@ -154,6 +156,14 @@ public class SplunkConfig {
      */
     @ConfigItem
     public Optional<String> metadataIndex;
+
+    /**
+     * Optional collection of key/value pairs to populate the "fields" key of event metadata. This key isn't
+     * applicable to raw data.
+     * https://docs.splunk.com/Documentation/Splunk/8.1.0/Data/FormateventsforHTTPEventCollector#Event_metadata
+     */
+    @ConfigItem
+    public Map<String, String> metadataFields = new HashMap<>();
 
     /**
      * Mirrors com.splunk.logging.HttpEventCollectorSender.SendMode

--- a/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkLogHandlerRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkLogHandlerRecorder.java
@@ -8,6 +8,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.logging.Handler;
 
@@ -62,6 +63,11 @@ public class SplunkLogHandlerRecorder {
         }
         config.metadataSource.ifPresent(s -> metadata.put(MetadataTags.SOURCE, s));
         metadata.put(MetadataTags.SOURCETYPE, config.metadataSourceType);
+
+        for (Entry<String, String> entry : config.metadataFields.entrySet()) {
+            metadata.put(entry.getKey(), entry.getValue());
+        }
+
         return metadata;
     }
 


### PR DESCRIPTION
Use Case:  Need to send events to splunk with a custom "namespace" metadata key

Usage:



Add any number of key/value pairs under the `quarkus.log.handler.splunk.metadata-fields` prefix, as seen [here](https://github.com/RedHatInsights/rhsm-subscriptions/commit/9fe579e992c858dea6a53ec6e1937582ae3f9801#diff-eafb1f5bcf1e73ea34808bfb92b7a43286a99382fc1fc30d54417f4fdf398ffbR57)

```
quarkus.log.handler.splunk.metadata-fields.namespace=edamame
quarkus.log.handler.splunk.metadata-fields.favoriteFruit=kiwi
```

![image](https://user-images.githubusercontent.com/19955562/160041536-8082bb17-d6d7-4b47-b42a-863bd69d5107.png)

