### PR TITLE
release 2.2

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,5 +1,5 @@
 name: Quarkiverse Extension
 release:
-  current-version: 2.1.0
-  next-version: 2.2.0-SNAPSHOT
+  current-version: 2.2.0
+  next-version: 2.3.0-SNAPSHOT
 


### PR DESCRIPTION
Hello, 

I Will create rhbq/2.2 after this PR
Next, we need to bump quarkus because the current bom is not compatible anymore with new testcontainer version  