### PR TITLE
Implemented support for raw events

### DIFF
--- a/deployment/src/test/java/io/quarkiverse/logging/splunk/AbstractMockServerTest.java
+++ b/deployment/src/test/java/io/quarkiverse/logging/splunk/AbstractMockServerTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.ClearType;
+import org.mockserver.model.HttpRequest;
 
 public abstract class AbstractMockServerTest {
 
@@ -21,6 +22,9 @@ public abstract class AbstractMockServerTest {
         // This needs to be done as early as possible, so Quarkus startup logs don't fail to be sent
         httpServer
                 .when(request().withPath("/services/collector/event/1.0"))
+                .respond(response().withStatusCode(200).withBody("{}"));
+        httpServer
+                .when(request().withPath("/services/collector/raw"))
                 .respond(response().withStatusCode(200).withBody("{}"));
         httpServer.when(request()).respond(response().withStatusCode(400));
     }
@@ -42,4 +46,13 @@ public abstract class AbstractMockServerTest {
     protected void awaitMockServer() {
         await().atMost(1, SECONDS).until(() -> httpServer.retrieveRecordedRequests(request()).length != 0);
     }
+
+    protected HttpRequest requestToJsonEndpoint() {
+        return request().withPath("/services/collector/event/1.0");
+    }
+
+    protected HttpRequest requestToRawEndpoint() {
+        return request().withPath("/services/collector/raw");
+    }
+
 }

--- a/deployment/src/test/java/io/quarkiverse/logging/splunk/LoggingSplunkMinimalConfigTest.java
+++ b/deployment/src/test/java/io/quarkiverse/logging/splunk/LoggingSplunkMinimalConfigTest.java
@@ -4,7 +4,6 @@ Contributor(s): Kevin Viet, Romain Quinio (Amadeus s.a.s.)
  */
 package io.quarkiverse.logging.splunk;
 
-import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.JsonBody.json;
 import static org.mockserver.model.Not.not;
 
@@ -30,13 +29,13 @@ class LoggingSplunkMinimalConfigTest extends AbstractMockServerTest {
     void indexIsNotSentIfUnspecified() {
         logger.info("hello splunk");
         awaitMockServer();
-        httpServer.verify(request().withBody(not(json("{ index: ''}"))));
+        httpServer.verify(requestToJsonEndpoint().withBody(not(json("{ index: ''}"))));
     }
 
     @Test
     void sourceTypeDefaultsToJson() {
         logger.info("hello splunk");
         awaitMockServer();
-        httpServer.verify(request().withBody(json("{ sourcetype: '_json'}")));
+        httpServer.verify(requestToJsonEndpoint().withBody(json("{ sourcetype: '_json'}")));
     }
 }

--- a/deployment/src/test/java/io/quarkiverse/logging/splunk/LoggingSplunkRawTest.java
+++ b/deployment/src/test/java/io/quarkiverse/logging/splunk/LoggingSplunkRawTest.java
@@ -1,0 +1,45 @@
+package io.quarkiverse.logging.splunk;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+class LoggingSplunkRawTest extends AbstractMockServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .withConfigurationResource("application-splunk-logging-raw.properties")
+            .withConfigurationResource("mock-server.properties")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    static final org.jboss.logging.Logger logger = org.jboss.logging.Logger.getLogger(LoggingSplunkRawTest.class);
+
+    @Test
+    void sendsTheRawEvent() {
+        logger.warn("hello splunk");
+        awaitMockServer();
+        httpServer.verify(requestToRawEndpoint().withBody("hello splunk"));
+    }
+
+    @Test
+    void sendsMetadata() {
+        logger.warn("hello splunk");
+        awaitMockServer();
+        httpServer.verify(requestToRawEndpoint()
+                .withQueryStringParameter("index", "myindex")
+                .withQueryStringParameter("source", "mysource")
+                .withQueryStringParameter("sourcetype", "mysourcetype"));
+    }
+
+    @Test
+    void sendsAuthenticationHeader() {
+        logger.warn("hello splunk");
+        awaitMockServer();
+        httpServer.verify(requestToRawEndpoint().withHeader(
+                "Authorization", "Splunk 12345678-1234-1234-1234-1234567890AB"));
+    }
+
+}

--- a/deployment/src/test/java/io/quarkiverse/logging/splunk/LoggingSplunkWithMetadataTest.java
+++ b/deployment/src/test/java/io/quarkiverse/logging/splunk/LoggingSplunkWithMetadataTest.java
@@ -4,7 +4,6 @@ Contributor(s): Kevin Viet, Romain Quinio (Amadeus s.a.s.)
  */
 package io.quarkiverse.logging.splunk;
 
-import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.JsonBody.json;
 import static org.mockserver.model.RegexBody.regex;
 
@@ -30,7 +29,7 @@ class LoggingSplunkWithMetadataTest extends AbstractMockServerTest {
     void clientAddsStructuredMetadata() {
         logger.error("hello splunk", new RuntimeException("test exception"));
         awaitMockServer();
-        httpServer.verify(request().withBody(json(
+        httpServer.verify(requestToJsonEndpoint().withBody(json(
                 "{ event: { message: 'hello splunk', " +
                         "logger:'io.quarkiverse.logging.splunk.LoggingSplunkWithMetadataTest', " +
                         "exception: 'test exception' }}"))
@@ -41,7 +40,7 @@ class LoggingSplunkWithMetadataTest extends AbstractMockServerTest {
     void clientAddsAdditionalMetadataFields() {
         logger.info("hello splunk");
         awaitMockServer();
-        httpServer.verify(request().withBody(
+        httpServer.verify(requestToJsonEndpoint().withBody(
                 json(
                         "{ fields: { "
                                 + "additional-field-0: 'important-information', "

--- a/deployment/src/test/resources/application-splunk-logging-raw.properties
+++ b/deployment/src/test/resources/application-splunk-logging-raw.properties
@@ -1,0 +1,9 @@
+quarkus.log.handler.splunk.enabled=true
+quarkus.log.level=INFO
+quarkus.log.handler.splunk.level=WARN
+quarkus.log.handler.splunk.format=%s%e
+quarkus.log.handler.splunk.token=12345678-1234-1234-1234-1234567890AB
+quarkus.log.handler.splunk.metadata-source=mysource
+quarkus.log.handler.splunk.metadata-source-type=mysourcetype
+quarkus.log.handler.splunk.metadata-index=myindex
+quarkus.log.handler.splunk.raw=true

--- a/docs/modules/ROOT/pages/config.adoc
+++ b/docs/modules/ROOT/pages/config.adoc
@@ -188,6 +188,14 @@ The optional name of the index by which the event data is to be stored. If set, 
 --|string 
 |
 
+a| [[quarkus-log-handler-splunk_quarkus.log.handler.splunk.raw]]`link:#quarkus-log-handler-splunk_quarkus.log.handler.splunk.raw[quarkus.log.handler.splunk.raw]`
+
+[.description]
+--
+Determines whether the events are sent in raw mode. In case the raw event (i.e. the actual log message) is not a JSON object you need to explicitly set a source type or Splunk will reject the event (the default source type, `_json`, assumes that the incoming event can be parsed as JSON)
+--|boolean
+|`false`
+
 |===
 ifndef::no-duration-note[]
 [NOTE]

--- a/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkConfig.java
@@ -166,6 +166,12 @@ public class SplunkConfig {
     public Map<String, String> metadataFields = new HashMap<>();
 
     /**
+     * Enables the "raw" mode
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean raw;
+
+    /**
      * Mirrors com.splunk.logging.HttpEventCollectorSender.SendMode
      */
     public enum SendMode {

--- a/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkLogHandlerRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkLogHandlerRecorder.java
@@ -40,8 +40,7 @@ public class SplunkLogHandlerRecorder {
 
     static HttpEventCollectorSender createSender(SplunkConfig config) {
         HttpEventCollectorErrorHandler.onError(new SplunkErrorCallback());
-        // Raw mode is supported now we could support it from now on
-        String type = "";
+        String type = config.raw ? "Raw" : "";
         // Timeout settings is not used and passing a null is correct regarding the code
         return new HttpEventCollectorSender(
                 config.url, config.token.get(), config.channel.orElse(""), type,


### PR DESCRIPTION
This MR introduces support for raw events: if `quarkus.log.handler.splunk.raw` is set to `true`, `HttpEventCollectorSender` sends the log message to `/services/collector/raw`.

A small caveat: if raw mode is enabled and the log message is not valid JSON, `quarkus.log.handler.splunk.metadata-source-type` must be changed to another source type. If the property has the default value (`_json`), then Splunk will reject any message that can't be parsed as JSON. A possibile solution would be using different defaults depending on the sender type (for example `generic_single_line` for raw events and `_json` for JSON events); I didn't implement this because I think that in most cases, for raw events, you want to set a specific source type anyway.

