### PR TITLE
Make SplunkErrorCallback public

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkErrorCallback.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkErrorCallback.java
@@ -20,7 +20,7 @@ import com.splunk.logging.HttpEventCollectorEventInfo;
 
 import io.quarkus.bootstrap.logging.InitialConfigurator;
 
-class SplunkErrorCallback implements ErrorCallback {
+public class SplunkErrorCallback implements ErrorCallback {
 
     Boolean consoleEnabled;
 


### PR DESCRIPTION
Users who wish to customize their Splunk HEC error behavior (such as
incrementing a Micrometer Counter) might still find it desirable to
delegate to SplunkErrorCallback for its useful core functionality.
Making the class public will allow for this use-case.

---

Here's an example of my situation:

```java
/**
 * A custom Quarkus-ified Splunk HEC error handler so that we can track failures in a Prometheus
 * metric and then alert if that metric exceeds acceptable parameters.
 */
@Slf4j
@ApplicationScoped
public class CountingSplunkErrorCallback implements ErrorCallback {

  private final ErrorCallback delegatedCallback;
  private final Counter failureCounter;

  public CountingSplunkErrorCallback(MeterRegistry meterRegistry) {
    // Only one ErrorCallback can be registered. The standard callback is useful in that it
    // prints the formatted error to stderr, so we'll delegate invocations of our ErrorCallback
    // to the StandardErrorCallback so that it can handle creating a human-readable record of the
    // issue.
    this.delegatedCallback = new SplunkErrorCallback();
    this.failureCounter = meterRegistry.counter("splunk.hec.message.failure.total");
  }

  @Override
  public void error(List<HttpEventCollectorEventInfo> data, Exception ex) {
    // Splunk HEC can batch log messages up. The contents of a failed batch come to us in the
    // HttpEventCollectorEventInfo list. The counter is meant to count the total number of
    // messages that failed to send (not the total number of failed transmissions) so we
    // increment by the size of the list.
    failureCounter.increment(data.size());
    delegatedCallback.error(data, ex);
  }

  void onStart(@Observes StartupEvent ev) {
    HttpEventCollectorErrorHandler.onError(this);
  }
}
```