### PR TITLE
Support async log handler

### DIFF
--- a/deployment/src/test/java/io/quarkiverse/logging/splunk/LoggingSplunkAsyncTest.java
+++ b/deployment/src/test/java/io/quarkiverse/logging/splunk/LoggingSplunkAsyncTest.java
@@ -1,0 +1,29 @@
+package io.quarkiverse.logging.splunk;
+
+import static org.mockserver.model.JsonBody.json;
+
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class LoggingSplunkAsyncTest extends AbstractMockServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .withConfigurationResource("application-splunk-logging-async.properties")
+            .withConfigurationResource("mock-server.properties")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    static final Logger logger = Logger.getLogger(LoggingSplunkAsyncTest.class);
+
+    @Test
+    void eventIsAJsonObjectWithMetadata() {
+        logger.warn("hello splunk");
+        awaitMockServer();
+        httpServer.verify(requestToJsonEndpoint().withBody(json("{ event: { message: 'hello splunk' }}")));
+    }
+}

--- a/deployment/src/test/resources/application-splunk-logging-async.properties
+++ b/deployment/src/test/resources/application-splunk-logging-async.properties
@@ -1,0 +1,10 @@
+quarkus.log.handler.splunk.enabled=true
+quarkus.log.handler.splunk.level=WARN
+quarkus.log.handler.splunk.format=%s%e
+quarkus.log.handler.splunk.token=12345678-1234-1234-1234-1234567890AB
+# Async at handler level
+quarkus.log.handler.splunk.async=true
+quarkus.log.handler.splunk.async.queue-length=512
+quarkus.log.handler.splunk.async.overflow=block
+# Async at HTTP client level
+quarkus.log.handler.splunk.send-mode=parallel

--- a/runtime/src/main/java/io/quarkiverse/logging/splunk/AsyncConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/splunk/AsyncConfig.java
@@ -1,0 +1,31 @@
+package io.quarkiverse.logging.splunk;
+
+import org.jboss.logmanager.handlers.AsyncHandler;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+/**
+ * Copy of io.quarkus.runtime.logging, as the fields are package-private.
+ */
+@ConfigGroup
+public class AsyncConfig {
+
+    /**
+     * Indicates whether to log asynchronously
+     */
+    @ConfigItem(name = ConfigItem.PARENT)
+    boolean enable;
+
+    /**
+     * The queue length to use before flushing writing
+     */
+    @ConfigItem(defaultValue = "512")
+    int queueLength;
+
+    /**
+     * Determine whether to block the publisher (rather than drop the message) when the queue is full
+     */
+    @ConfigItem(defaultValue = "block")
+    AsyncHandler.OverflowAction overflow;
+}

--- a/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkConfig.java
@@ -181,4 +181,11 @@ public class SplunkConfig {
         SEQUENTIAL,
         PARALLEL
     }
+
+    /**
+     * AsyncHandler config
+     * <p>
+     * This is independent of the SendMode, i.e. whether the HTTP client is async or not.
+     */
+    AsyncConfig async;
 }


### PR DESCRIPTION
Resolves  #114

This is based on what Quarkus is doing internally: https://github.com/quarkusio/quarkus/blob/f2508a9d89d5fa258e742c14aee7eeaf0bbc2a72/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java#L577

Would be nice to add a section about async in the doc.