### PR TITLE
Let Quarkus manage testcontainers version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,6 @@
     <quarkus.version>2.2.3.Final</quarkus.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <splunk.logging.version>1.11.5</splunk.logging.version>
-    <testcontainers.version>1.15.3</testcontainers.version>
 
     <!-- https://antoniogoncalves.org/2012/12/13/lets-turn-integration-tests-with-maven-to-a-first-class-citizen/ -->
     <skipTests>false</skipTests>
@@ -100,16 +99,6 @@
         <groupId>io.quarkiverse.logging.splunk</groupId>
         <artifactId>quarkus-logging-splunk-deployment</artifactId>
         <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.testcontainers</groupId>
-        <artifactId>testcontainers</artifactId>
-        <version>${testcontainers.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.testcontainers</groupId>
-        <artifactId>junit-jupiter</artifactId>
-        <version>${testcontainers.version}</version>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
Replaces #109 

As Quarkus manages the docker-java version, if we override testcontainers version we can end up with conflicts.