### PR TITLE
Resync the doc and retry release 2.4

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,5 +1,5 @@
 name: Quarkiverse Extension
 release:
-  current-version: 2.4.0
+  current-version: 2.4.1
   next-version: 2.5.0-SNAPSHOT
 

--- a/docs/modules/ROOT/pages/includes/quarkus-log-handler-splunk.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-log-handler-splunk.adoc
@@ -194,6 +194,33 @@ Determines whether the events are sent in raw mode. In case the raw event (i.e. 
 |`false`
 
 
+a| [[quarkus-log-handler-splunk_quarkus.log.handler.splunk.async]]`link:#quarkus-log-handler-splunk_quarkus.log.handler.splunk.async[quarkus.log.handler.splunk.async]`
+
+[.description]
+--
+Indicates whether to log asynchronously
+--|boolean 
+|`false`
+
+
+a| [[quarkus-log-handler-splunk_quarkus.log.handler.splunk.async.queue-length]]`link:#quarkus-log-handler-splunk_quarkus.log.handler.splunk.async.queue-length[quarkus.log.handler.splunk.async.queue-length]`
+
+[.description]
+--
+The queue length to use before flushing writing
+--|int 
+|`512`
+
+
+a| [[quarkus-log-handler-splunk_quarkus.log.handler.splunk.async.overflow]]`link:#quarkus-log-handler-splunk_quarkus.log.handler.splunk.async.overflow[quarkus.log.handler.splunk.async.overflow]`
+
+[.description]
+--
+Determine whether to block the publisher (rather than drop the message) when the queue is full
+--|`block`, `discard` 
+|`block`
+
+
 a| [[quarkus-log-handler-splunk_quarkus.log.handler.splunk.metadata-fields-metadata-fields]]`link:#quarkus-log-handler-splunk_quarkus.log.handler.splunk.metadata-fields-metadata-fields[quarkus.log.handler.splunk.metadata-fields]`
 
 [.description]

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -41,6 +41,8 @@
                   <filtering>false</filtering>
                 </resource>
               </resources>
+              <!-- Don't activate during releasing, as unstaged changes will block the rebase -->
+              <skip>${releaseVersion}</skip>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Failing the regular build if the doc in not synched might be risky if Quarkus changes the doc output due to upstream nightly builds