### PR TITLE
Update the link to splunkiverse indexed fields

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -42,7 +42,7 @@ By default, only few structured metadata computed by the HEC client library are 
 Extra metadata can be added via configuration (`quarkus.log.handler.splunk.include-thread-name`, etc.).
 
 The extension also provides the support of the resolution of MDC scoped properties, as defined in https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.0/html/configuration_guide/logging_with_jboss_eap#log_formatters[JBoss supported formatters].
-MDC key/values are sent as https://docs.splunk.com/Splexicon\:Indexedfield[indexed fields] in the event.
+MDC key/values are sent as link:++https://docs.splunk.com/Splexicon:Indexedfield++[indexed fields] in the event.
 
 A structured log event looks like:
 


### PR DESCRIPTION
The default asciidoc formatting was misreading the full length of the link & the escaping of the colon.