### PR TITLE
Fix flaky LoggingSplunkSendErrorTest

### DIFF
--- a/deployment/src/test/java/io/quarkiverse/logging/splunk/LoggingSplunkSendErrorTest.java
+++ b/deployment/src/test/java/io/quarkiverse/logging/splunk/LoggingSplunkSendErrorTest.java
@@ -39,8 +39,9 @@ class LoggingSplunkSendErrorTest {
     @BeforeAll
     public static void setUpOnce() {
         httpServer = ClientAndServer.startClientAndServer(8088);
-        // Reject all requests (ex: wrong token, ...)
-        httpServer.when(request()).respond(response().withStatusCode(401));
+        // Reject a specific request (ex: wrong token, ...)
+        httpServer.when(request().withBody(json("{ event: { message:'error splunk'} }")))
+                .respond(response().withStatusCode(401));
     }
 
     @AfterAll

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -36,7 +36,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
+      <artifactId>mockito-inline</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This should hopefully fix the random failure in https://github.com/quarkiverse/quarkiverse/issues/37 and other PR builds.

Also replace mockito-core by mockito-inline, so that spies work on JDK17 classes in SplunkErrorCallbackTest.