### PR TITLE
Make metadata-source-type optional

### DIFF
--- a/deployment/src/test/java/io/quarkiverse/logging/splunk/LoggingSplunkFlatSerializationTest.java
+++ b/deployment/src/test/java/io/quarkiverse/logging/splunk/LoggingSplunkFlatSerializationTest.java
@@ -33,7 +33,7 @@ public class LoggingSplunkFlatSerializationTest extends AbstractMockServerTest {
         logger.warn("hello splunk");
         awaitMockServer();
         httpServer.verify(requestToJsonEndpoint().withBody(json(
-                "{ source: 'mysource', sourcetype: 'mysourcetype', index: 'myindex'} "))
+                "{ source: 'mysource', index: 'myindex'} "))
                 .withBody(regex(".*host.*")));
     }
 

--- a/deployment/src/test/resources/application-splunk-logging-flat.properties
+++ b/deployment/src/test/resources/application-splunk-logging-flat.properties
@@ -5,7 +5,6 @@ quarkus.log.handler.splunk.level=WARN
 quarkus.log.handler.splunk.format=%s%e
 quarkus.log.handler.splunk.token=12345678-1234-1234-1234-1234567890AB
 quarkus.log.handler.splunk.metadata-source=mysource
-quarkus.log.handler.splunk.metadata-source-type=mysourcetype
 quarkus.log.handler.splunk.metadata-index=myindex
 quarkus.log.handler.splunk.include-exception=true
 quarkus.log.handler.splunk.include-logger-name=true

--- a/docs/modules/ROOT/pages/includes/quarkus-log-handler-splunk.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-log-handler-splunk.adoc
@@ -32,7 +32,7 @@ a| [[quarkus-log-handler-splunk_quarkus.log.handler.splunk.url]]`link:#quarkus-l
 [.description]
 --
 Splunk HEC endpoint base url. 
- With raw events, the endpoint targeted is /services/collector/raw. With flat or nested JSON events, the endpoint targeted is /services/collector/events/1.0.
+ With raw events, the endpoint targeted is /services/collector/raw. With flat or nested JSON events, the endpoint targeted is /services/collector/event/1.0.
 --|string 
 |`https://localhost:8088/`
 
@@ -170,10 +170,10 @@ a| [[quarkus-log-handler-splunk_quarkus.log.handler.splunk.metadata-source-type]
 
 [.description]
 --
-The source type value to assign to the event data https://docs.splunk.com/Documentation/Splunk/latest/Data/FormateventsforHTTPEventCollector++#++Event_metadata 
- A given source type may have indexed fields extraction enabled, which is the case of the default built-in _json.
+The optional format of the events, to enable some parsing on Splunk side. https://docs.splunk.com/Documentation/Splunk/latest/Data/FormateventsforHTTPEventCollector++#++Event_metadata 
+ A given source type may have indexed fields extraction enabled, which is the case of the built-in _json used for nested serialization.
 --|string 
-|`_json`
+|`_json for nested serialization, not set otherwise`
 
 
 a| [[quarkus-log-handler-splunk_quarkus.log.handler.splunk.metadata-index]]`link:#quarkus-log-handler-splunk_quarkus.log.handler.splunk.metadata-index[quarkus.log.handler.splunk.metadata-index]`
@@ -199,9 +199,9 @@ a| [[quarkus-log-handler-splunk_quarkus.log.handler.splunk.serialization]]`link:
 [.description]
 --
 The format of the payload.  
- - With raw serialization, the log message is sent 'as is' in the HTTP body. Metadata can only be common to a whole batch and are sent via HTTP parameters.
+ - With raw serialization, the log message is sent 'as is' in the HTTP body. Metadata can only be common to a whole batch and are sent via HTTP parameters. 
  - With nested serialization, the log message is sent into a 'message' field of a JSON structure which also contains dynamic metadata. 
- - With flat serialization, the log message is sent into the root 'event' field. Dynamic metadata is sent via the 'fields' root object.  TODO Switch default to 'flat'
+ - With flat serialization, the log message is sent into the root 'event' field. Dynamic metadata is sent via the 'fields' root object.
 --|`raw`, `nested`, `flat` 
 |`nested`
 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -89,6 +89,10 @@ Other metadata can be added:
 
 |===
 
+A structured query to Splunk HEC looks like:
+
+curl -k -v -X POST https://localhost:8080/services/collector/event/1.0 -H "Content-type: application/json; profile=\"urn:splunk:event:1.0\"; charset=utf-8" -H "Authorization: Splunk 29fe2838-cab6-4d17-a392-37b7b8f41f75" -d@events.json
+
 .Nested serialization example
 [source,json]
 ----
@@ -97,7 +101,7 @@ Other metadata can be added:
   "host": "hostname",
   "source": "mysource",
   "sourcetype": "_json",
-  "index": "myindex",
+  "index": "main",
   "event": {
     "message": "2023-01-06 ERROR The log message",
     "logger": "com.acme.MyClass",
@@ -120,8 +124,7 @@ Other metadata can be added:
   "time": "1673001538.042",
   "host": "hostname",
   "source": "mysource",
-  "sourcetype": "_json",
-  "index": "myindex",
+  "index": "main",
   "event": "2023-01-06 ERROR The log message",
   "fields": {
     "severity": "ERROR",
@@ -170,7 +173,7 @@ Lib --> App
 end
 group HTTP client - multiple connections in parallel mode.
 OkHttp -> OkHttp: Peek from queue
-OkHttp -> HEC: HTTP POST /services/collector/events/1.0
+OkHttp -> HEC: HTTP POST /services/collector/event/1.0
 HEC --> OkHttp: 200
 alt status code != 200
 OkHttp --> Lib: handle errors
@@ -219,7 +222,7 @@ SplunkLogHandler --> AsyncHandler
 end
 group HTTP client - multiple connections in parallel mode.
 OkHttp -> OkHttp: Peek from queue
-OkHttp -> HEC: HTTP POST /services/collector/events/1.0
+OkHttp -> HEC: HTTP POST /services/collector/event/1.0
 HEC --> OkHttp: 200
 alt status code != 200
 OkHttp --> Lib: handle errors

--- a/integration-test/src/main/resources/application.properties
+++ b/integration-test/src/main/resources/application.properties
@@ -1,5 +1,7 @@
 quarkus.log.handler.splunk.url=https://localhost:8099
+quarkus.log.handler.splunk.index=main
 quarkus.log.handler.splunk.token=29fe2838-cab6-4d17-a392-37b7b8f41f75
 quarkus.log.handler.splunk.batch-interval=1s
 quarkus.log.handler.splunk.disable-certificate-validation=true
 quarkus.log.console.enable=true
+quarkus.log.handler.splunk.serialization=nested

--- a/integration-test/src/test/java/io/quarkiverse/logging/splunk/SplunkLoggingTest.java
+++ b/integration-test/src/test/java/io/quarkiverse/logging/splunk/SplunkLoggingTest.java
@@ -30,6 +30,7 @@ public class SplunkLoggingTest {
         Thread.sleep(2000);
 
         // XML REST API - see https://docs.splunk.com/Documentation/Splunk/latest/RESTREF/RESTsearch#search.2Fjobs
+        // Note: we can't assert on fields, which require 2 calls: GET /services/search/jobs and GET /services/search/jobs/<id>
         RestAssured.given()
                 .request()
                 .formParam("search", "search \"hello splunk\"")

--- a/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkConfig.java
@@ -36,7 +36,7 @@ public class SplunkConfig {
      * Splunk HEC endpoint base url.
      * <p>
      * With raw events, the endpoint targeted is /services/collector/raw.
-     * With flat or nested JSON events, the endpoint targeted is /services/collector/events/1.0.
+     * With flat or nested JSON events, the endpoint targeted is /services/collector/event/1.0.
      */
     @ConfigItem(defaultValue = "https://localhost:8088/")
     public String url;
@@ -144,13 +144,14 @@ public class SplunkConfig {
     public Optional<String> metadataSource;
 
     /**
-     * The source type value to assign to the event data
+     * The optional format of the events, to enable some parsing on Splunk side.
      * https://docs.splunk.com/Documentation/Splunk/latest/Data/FormateventsforHTTPEventCollector#Event_metadata
      * <p>
-     * A given source type may have indexed fields extraction enabled, which is the case of the default built-in _json.
+     * A given source type may have indexed fields extraction enabled, which is the case of the built-in _json used for nested
+     * serialization.
      */
-    @ConfigItem(defaultValue = "_json")
-    public String metadataSourceType;
+    @ConfigItem(defaultValueDocumentation = "_json for nested serialization, not set otherwise")
+    public Optional<String> metadataSourceType;
 
     /**
      * The optional name of the index by which the event data is to be stored. If set, it must be within the
@@ -197,7 +198,6 @@ public class SplunkConfig {
      * <li>With flat serialization, the log message is sent into the root 'event' field. Dynamic metadata is sent via the
      * 'fields' root object.
      * </ul>
-     * TODO Switch default to 'flat'
      */
     @ConfigItem(defaultValue = "nested")
     public SerializationFormat serialization;

--- a/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkLogHandlerRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkLogHandlerRecorder.java
@@ -66,7 +66,6 @@ public class SplunkLogHandlerRecorder {
         HashMap<String, String> metadata = new HashMap<>();
         // Note: sending an empty index is invalid, the index property has to be omitted
         config.metadataIndex.ifPresent(s -> metadata.put(MetadataTags.INDEX, s));
-        //metadata.put(MetadataTags.INDEX, config.metadataIndex.orElse(""));
         try {
             String hostName = InetAddress.getLocalHost().getHostName();
             metadata.put(MetadataTags.HOST, config.metadataHost.orElse(hostName));
@@ -74,7 +73,13 @@ public class SplunkLogHandlerRecorder {
             // Ignore
         }
         config.metadataSource.ifPresent(s -> metadata.put(MetadataTags.SOURCE, s));
-        metadata.put(MetadataTags.SOURCETYPE, config.metadataSourceType);
+
+        if (config.metadataSourceType.isPresent()) {
+            metadata.put(MetadataTags.SOURCETYPE, config.metadataSourceType.get());
+        } else if (config.serialization == SplunkConfig.SerializationFormat.NESTED) {
+            metadata.put(MetadataTags.SOURCETYPE, "_json");
+        }
+
         metadata.putAll(config.metadataFields);
         return metadata;
     }


### PR DESCRIPTION
In flat serialization setting metadata-source-type to _json prevent the indexing on splunk side. In flat and raw mode, metadata-source-type is no longer sent unless explicitly configured.

Also fix a typo in the documented structured endpoint path.

Note: we can't easily test both modes in the same integration test without https://github.com/quarkiverse/quarkus-logging-splunk/issues/156