### PR TITLE
Release 3.0.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,5 +1,5 @@
 name: Quarkiverse Extension
 release:
-  current-version: 2.5.1
-  next-version: 2.6.0-SNAPSHOT
+  current-version: 3.0.0
+  next-version: 3.1.0-SNAPSHOT
 


### PR DESCRIPTION
No actual known breaking change, but bumping major version to make compatibility with Quarkus 3.x more explict.