### PR TITLE
Replace mockito-inline by mockito-core

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -36,7 +36,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
As of Mockito 5.3, mockito-inline is no longer published, it has become the default since mockito 5.0

Relates to https://github.com/quarkusio/quarkus/pull/33037
This should fix the nightly https://github.com/quarkiverse/quarkiverse/issues/37#issuecomment-1534191862