### PR TITLE
Make SplunkErrorCallback's contructors public

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkErrorCallback.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkErrorCallback.java
@@ -28,14 +28,14 @@ public class SplunkErrorCallback implements ErrorCallback {
 
     PrintStream stderr;
 
-    SplunkErrorCallback() {
+    public SplunkErrorCallback() {
         this(System.out, System.err); // NOSONAR
     }
 
     /**
      * For unit tests
      */
-    SplunkErrorCallback(PrintStream stdout, PrintStream stderr) {
+    public SplunkErrorCallback(PrintStream stdout, PrintStream stderr) {
         this.stdout = stdout;
         this.stderr = stderr;
     }


### PR DESCRIPTION
This is a follow-up pull request after https://github.com/quarkiverse/quarkus-logging-splunk/pull/111. 

Having the constructors protected makes the class SplunkErrorCallback still unusable for the same use-case.