### PR TITLE
chore: Release 3.1.2

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,5 +1,5 @@
 name: Quarkiverse Extension
 release:
-  current-version: 3.1.1
+  current-version: 3.1.2
   next-version: 3.2.0-SNAPSHOT
 


### PR DESCRIPTION
Forgot that we need to open a PR for workflow to be triggered to release, so switching to 3.1.2 directly