### PR TITLE
2.5.x backports

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-log-handler-splunk.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-log-handler-splunk.adoc
@@ -99,7 +99,7 @@ a| [[quarkus-log-handler-splunk_quarkus.log.handler.splunk.batch-size-bytes]]`li
 --
 Maximum total size in bytes of events in a batch. By default 10KB, if 0 no batching.
 --|long 
-|`10`
+|`10240`
 
 
 a| [[quarkus-log-handler-splunk_quarkus.log.handler.splunk.max-retries]]`link:#quarkus-log-handler-splunk_quarkus.log.handler.splunk.max-retries[quarkus.log.handler.splunk.max-retries]`

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <quarkus.version>2.2.3.Final</quarkus.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
-    <splunk.logging.version>1.11.7</splunk.logging.version>
+    <splunk.logging.version>1.11.8</splunk.logging.version>
 
     <!-- https://antoniogoncalves.org/2012/12/13/lets-turn-integration-tests-with-maven-to-a-first-class-citizen/ -->
     <skipTests>false</skipTests>

--- a/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkConfig.java
@@ -89,8 +89,8 @@ public class SplunkConfig {
     /**
      * Maximum total size in bytes of events in a batch. By default 10KB, if 0 no batching.
      */
-    @ConfigItem(defaultValue = "10")
-    public long batchSizeBytes;
+    @ConfigItem(defaultValue = "10240")
+    public long batchSizeBytes = 10 * 1024;
 
     /**
      * Maximum number of retries in case of I/O exceptions with HEC connection.

--- a/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkLogHandlerRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkLogHandlerRecorder.java
@@ -51,7 +51,7 @@ public class SplunkLogHandlerRecorder {
         // Timeout settings is not used and passing a null is correct regarding the code
         HttpEventCollectorSender sender = new HttpEventCollectorSender(
                 config.url, config.token.get(), config.channel.orElse(""), type,
-                config.batchInterval.getSeconds(),
+                config.batchInterval.toMillis(),
                 config.batchSizeCount, config.batchSizeBytes,
                 config.sendMode.name().toLowerCase(), buildMetadata(config), null);
         if (config.serialization == SplunkConfig.SerializationFormat.FLAT) {


### PR DESCRIPTION
Backporting bugfixes to the Quarkus 2.x branch:
* #228
* CVE fix for https://github.com/splunk/splunk-library-javalogging/releases/tag/1.11.8