### PR TITLE
Add extension metadata, incl. sponsor

### DIFF
--- a/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,16 @@
+# https://quarkus.io/version/main/guides/extension-metadata#quarkus-extension-yaml
+name: "Logging Splunk"
+description: "Send logs to a Splunk HTTP Event Collector (HEC)"
+sponsor: "Amadeus IT Group"
+metadata:
+  short-name: "logging-splunk"
+  keywords:
+    - "logging"
+    - "splunk"
+    - "hec"
+  categories:
+    - "logging"
+  status: "stable"
+  guide: https://docs.quarkiverse.io/quarkus-logging-splunk/dev/index.html
+  config:
+    - "quarkus.log.handler.splunk"


### PR DESCRIPTION
This will fix some data that is otherwise deducted from Maven (name, RedHat as sponsor) and adding missing data (no categories, no status, and no link to guide). These metadata are used on https://quarkus.io/extensions/io.quarkiverse.logging.splunk/quarkus-logging-splunk/