### PR TITLE
feat: support named log filter

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/logging/splunk/LoggingSplunkProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/logging/splunk/LoggingSplunkProcessor.java
@@ -5,8 +5,16 @@ Contributor(s): Kevin Viet, Romain Quinio (Amadeus s.a.s.)
 package io.quarkiverse.logging.splunk;
 
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Filter;
 
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
 
 import com.splunk.logging.HttpEventCollectorMiddleware;
 import com.splunk.logging.HttpEventCollectorSender;
@@ -22,8 +30,19 @@ import io.quarkus.deployment.builditem.LogHandlerBuildItem;
 import io.quarkus.deployment.builditem.NamedLogHandlersBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
+import io.quarkus.deployment.util.JandexUtil;
+import io.quarkus.logging.LoggingFilter;
+import io.quarkus.runtime.logging.DiscoveredLogComponents;
 
 class LoggingSplunkProcessor {
+
+    public static final DotName LOGGING_FILTER = DotName.createSimple(LoggingFilter.class.getName());
+
+    private static final DotName FILTER = DotName.createSimple(Filter.class.getName());
+
+    private static final String ILLEGAL_LOGGING_FILTER_USE_MESSAGE = "'@" + LoggingFilter.class.getName()
+            + "' can only be used on classes that implement '"
+            + Filter.class.getName() + "' and that are marked as final.";
 
     private static final String FEATURE = "logging-splunk";
 
@@ -34,14 +53,18 @@ class LoggingSplunkProcessor {
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
-    LogHandlerBuildItem logHandler(SplunkLogHandlerRecorder recorder, SplunkConfig config) {
-        return new LogHandlerBuildItem(recorder.initializeHandler(config));
+    LogHandlerBuildItem logHandler(SplunkLogHandlerRecorder recorder, SplunkConfig config,
+            CombinedIndexBuildItem combinedIndexBuildItem) {
+        DiscoveredLogComponents discoveredLogComponents = discoverLogComponents(combinedIndexBuildItem.getIndex());
+        return new LogHandlerBuildItem(recorder.initializeHandler(config, discoveredLogComponents));
     }
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
-    NamedLogHandlersBuildItem logNamedHandlers(SplunkLogHandlerRecorder recorder, SplunkConfig config) {
-        return new NamedLogHandlersBuildItem(recorder.initializeHandlers(config));
+    NamedLogHandlersBuildItem logNamedHandlers(SplunkLogHandlerRecorder recorder, SplunkConfig config,
+            CombinedIndexBuildItem combinedIndexBuildItem) {
+        DiscoveredLogComponents discoveredLogComponents = discoverLogComponents(combinedIndexBuildItem.getIndex());
+        return new NamedLogHandlersBuildItem(recorder.initializeHandlers(config, discoveredLogComponents));
     }
 
     @BuildStep
@@ -67,5 +90,54 @@ class LoggingSplunkProcessor {
                     .constructors()
                     .build());
         }
+    }
+
+    /**
+     * Copied from io.quarkus.deployment.logging.LoggingResourceProcessor, as not exposed as a build item.
+     */
+    private DiscoveredLogComponents discoverLogComponents(IndexView index) {
+        Collection<AnnotationInstance> loggingFilterInstances = index.getAnnotations(LOGGING_FILTER);
+        DiscoveredLogComponents result = new DiscoveredLogComponents();
+
+        Map<String, String> filtersMap = new HashMap<>();
+        for (AnnotationInstance instance : loggingFilterInstances) {
+            AnnotationTarget target = instance.target();
+            if (target.kind() != AnnotationTarget.Kind.CLASS) {
+                throw new IllegalStateException("Unimplemented mode of use of '" + LoggingFilter.class.getName() + "'");
+            }
+            ClassInfo classInfo = target.asClass();
+            boolean isFilterImpl = false;
+            ClassInfo currentClassInfo = classInfo;
+            while ((currentClassInfo != null) && (!JandexUtil.DOTNAME_OBJECT.equals(currentClassInfo.name()))) {
+                boolean hasFilterInterface = false;
+                List<DotName> ifaces = currentClassInfo.interfaceNames();
+                for (DotName iface : ifaces) {
+                    if (FILTER.equals(iface)) {
+                        hasFilterInterface = true;
+                        break;
+                    }
+                }
+                if (hasFilterInterface) {
+                    isFilterImpl = true;
+                    break;
+                }
+                currentClassInfo = index.getClassByName(currentClassInfo.superName());
+            }
+            if (!isFilterImpl) {
+                throw new RuntimeException(
+                        ILLEGAL_LOGGING_FILTER_USE_MESSAGE + " Offending class is '" + classInfo.name() + "'");
+            }
+
+            String filterName = instance.value("name").asString();
+            if (filtersMap.containsKey(filterName)) {
+                throw new RuntimeException("Filter '" + filterName + "' was defined multiple times.");
+            }
+            filtersMap.put(filterName, classInfo.name().toString());
+        }
+        if (!filtersMap.isEmpty()) {
+            result.setNameToFilterClass(filtersMap);
+        }
+
+        return result;
     }
 }

--- a/deployment/src/test/java/io/quarkiverse/logging/splunk/LoggingSplunkFilteringTest.java
+++ b/deployment/src/test/java/io/quarkiverse/logging/splunk/LoggingSplunkFilteringTest.java
@@ -1,0 +1,50 @@
+/*
+Copyright (c) 2021 Amadeus s.a.s.
+Contributor(s): Kevin Viet, Romain Quinio (Amadeus s.a.s.)
+ */
+package io.quarkiverse.logging.splunk;
+
+import static org.mockserver.model.JsonBody.json;
+import static org.mockserver.model.RegexBody.regex;
+
+import java.util.logging.Filter;
+import java.util.logging.LogRecord;
+
+import org.jboss.logging.Logger;
+import org.jboss.logmanager.Level;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.logging.LoggingFilter;
+import io.quarkus.test.QuarkusUnitTest;
+
+class LoggingSplunkFilteringTest extends AbstractMockServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .withConfigurationResource("application-splunk-logging-filtering.properties")
+            .withConfigurationResource("mock-server.properties")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    static final Logger logger = Logger.getLogger(LoggingSplunkFilteringTest.class);
+
+    @Test
+    void filterShouldBeCalled() {
+        logger.info("hello splunk");
+        awaitMockServer();
+        httpServer.verify(
+                requestToJsonEndpoint().withBody(regex(".*hello splunk.*")).withBody(json("{ event: { severity:'ERROR' }}")));
+    }
+
+    @LoggingFilter(name = "my-filter")
+    public static class MyFilter implements Filter {
+
+        @Override
+        public boolean isLoggable(LogRecord record) {
+            record.setLevel(Level.ERROR);
+            return true;
+        }
+    }
+}

--- a/deployment/src/test/resources/application-splunk-logging-filtering.properties
+++ b/deployment/src/test/resources/application-splunk-logging-filtering.properties
@@ -1,0 +1,3 @@
+quarkus.log.handler.splunk.enabled=true
+quarkus.log.handler.splunk.token=12345678-1234-1234-1234-1234567890AB
+quarkus.log.handler.splunk.filter=my-filter

--- a/docs/modules/ROOT/pages/includes/quarkus-log-handler-splunk.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-log-handler-splunk.adoc
@@ -451,6 +451,23 @@ endif::add-copy-button-to-env-var[]
 |`nested`
 
 
+a| [[quarkus-log-handler-splunk_quarkus-log-handler-splunk-filter]]`link:#quarkus-log-handler-splunk_quarkus-log-handler-splunk-filter[quarkus.log.handler.splunk.filter]`
+
+
+[.description]
+--
+The name of the named filter to link to the splunk handler.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_HANDLER_SPLUNK_FILTER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LOG_HANDLER_SPLUNK_FILTER+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
 a| [[quarkus-log-handler-splunk_quarkus-log-handler-splunk-async]]`link:#quarkus-log-handler-splunk_quarkus-log-handler-splunk-async[quarkus.log.handler.splunk.async]`
 
 
@@ -978,6 +995,23 @@ endif::add-copy-button-to-env-var[]
 -- a|
 `raw`, `nested`, `flat` 
 |`nested`
+
+
+a| [[quarkus-log-handler-splunk_quarkus-log-handler-splunk-named-handlers-filter]]`link:#quarkus-log-handler-splunk_quarkus-log-handler-splunk-named-handlers-filter[quarkus.log.handler.splunk."named-handlers".filter]`
+
+
+[.description]
+--
+The name of the named filter to link to the splunk handler.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_HANDLER_SPLUNK__NAMED_HANDLERS__FILTER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LOG_HANDLER_SPLUNK__NAMED_HANDLERS__FILTER+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
 
 
 a| [[quarkus-log-handler-splunk_quarkus-log-handler-splunk-named-handlers-async]]`link:#quarkus-log-handler-splunk_quarkus-log-handler-splunk-named-handlers-async[quarkus.log.handler.splunk."named-handlers".async]`

--- a/integration-test/src/main/java/io/quarkiverse/logging/splunk/SensitiveLogFilter.java
+++ b/integration-test/src/main/java/io/quarkiverse/logging/splunk/SensitiveLogFilter.java
@@ -1,0 +1,18 @@
+package io.quarkiverse.logging.splunk;
+
+import java.util.logging.Filter;
+import java.util.logging.LogRecord;
+
+import io.quarkus.logging.LoggingFilter;
+
+@LoggingFilter(name = "sensitive-filter")
+public class SensitiveLogFilter implements Filter {
+
+    @Override
+    public boolean isLoggable(LogRecord record) {
+        if (record.getMessage().contains("Sensitive")) {
+            record.setMessage(record.getMessage().replace("Sensitive", "*********"));
+        }
+        return true;
+    }
+}

--- a/integration-test/src/main/java/io/quarkiverse/logging/splunk/SplunkHandlerResource.java
+++ b/integration-test/src/main/java/io/quarkiverse/logging/splunk/SplunkHandlerResource.java
@@ -21,6 +21,7 @@ public class SplunkHandlerResource {
     public void log() {
         MDC.put("mdc-key", "mdc-value");
         logger.info("hello splunk");
+        logger.info("Sensitive log");
         MDC.remove("mdc-key");
     }
 }

--- a/integration-test/src/main/resources/application.properties
+++ b/integration-test/src/main/resources/application.properties
@@ -1,6 +1,8 @@
+quarkus.log.console.enable=true
+quarkus.log.console.filter=sensitive-filter
 quarkus.log.handler.splunk.metadata-index=main
 quarkus.log.handler.splunk.batch-interval=1s
 quarkus.log.handler.splunk.middleware=io.quarkiverse.logging.splunk.MyMiddleware
-quarkus.log.console.enable=true
 quarkus.log.handler.splunk.serialization=nested
+quarkus.log.handler.splunk.filter=sensitive-filter
 quarkus.log.handler.splunk.devservices.enabled=true

--- a/integration-test/src/test/java/io/quarkiverse/logging/splunk/SplunkLoggingTest.java
+++ b/integration-test/src/test/java/io/quarkiverse/logging/splunk/SplunkLoggingTest.java
@@ -15,6 +15,7 @@ import io.quarkiverse.logging.splunk.test.LoggingSplunkInjectingTestResource;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
+import io.restassured.response.Response;
 
 @QuarkusTest
 @QuarkusTestResource(LoggingSplunkInjectingTestResource.class)
@@ -27,20 +28,22 @@ public class SplunkLoggingTest {
         RestAssured.given().when().get("/log-to-splunk").then().statusCode(NO_CONTENT.getStatusCode());
         Thread.sleep(2000);
 
+        searchSplunk("hello splunk").then().statusCode(200).body(containsString("hello splunk"), containsString("mdc-value"),
+                containsString("myValue"));
+        searchSplunk("********* log").then().statusCode(200);
+    }
+
+    private Response searchSplunk(String log) {
         // XML REST API - see https://docs.splunk.com/Documentation/Splunk/latest/RESTREF/RESTsearch#search.2Fjobs
         // Note: we can't assert on fields, which require 2 calls: GET /services/search/jobs and GET /services/search/jobs/<id>
-        RestAssured.given()
+        return RestAssured.given()
                 .request()
-                .formParam("search", "search \"hello splunk\"")
+                .formParam("search", "search \"" + log + "\"")
                 .formParam("exec_mode", "oneshot")
                 //.formParam("output_mode", "json")
                 .relaxedHTTPSValidation()
                 .auth().basic("admin", "admin123")
                 .log().all()
-                .post(splunkApiUrl + "/services/search/jobs")
-                .then().statusCode(200).body(
-                        containsString("hello splunk"),
-                        containsString("mdc-value"),
-                        containsString("myValue"));
+                .post(splunkApiUrl + "/services/search/jobs");
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkHandlerConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkHandlerConfig.java
@@ -224,6 +224,12 @@ public class SplunkHandlerConfig {
     public SerializationFormat serialization = SerializationFormat.NESTED;
 
     /**
+     * The name of the named filter to link to the splunk handler.
+     */
+    @ConfigItem
+    public Optional<String> filter;
+
+    /**
      * AsyncHandler config
      * <p>
      * This is independent of the SendMode, i.e. whether the HTTP client is async or not.

--- a/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkLogHandler.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkLogHandler.java
@@ -4,12 +4,15 @@ Contributor(s): Kevin Viet, Romain Quinio (Amadeus s.a.s.)
  */
 package io.quarkiverse.logging.splunk;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.logging.ErrorManager;
+import java.util.logging.Filter;
 import java.util.logging.Formatter;
 
 import org.jboss.logmanager.ExtHandler;
 import org.jboss.logmanager.ExtLogRecord;
+import org.jboss.logmanager.filters.AllFilter;
 
 import com.splunk.logging.HttpEventCollectorResendMiddleware;
 import com.splunk.logging.HttpEventCollectorSender;
@@ -77,5 +80,15 @@ public class SplunkLogHandler extends ExtHandler {
             reportError("Formatting error", ex, ErrorManager.FORMAT_FAILURE);
         }
         return formatted;
+    }
+
+    @Override
+    public void setFilter(Filter newFilter) throws SecurityException {
+        if (this.getFilter() != null) {
+            // setFilter gets called by io.quarkus.runtime.logging.LoggingSetupRecorder with cleanupFilter
+            super.setFilter(new AllFilter(List.of(this.getFilter(), newFilter)));
+        } else {
+            super.setFilter(newFilter);
+        }
     }
 }


### PR DESCRIPTION
Closes #244 

Some logic has to be duplicated from LoggingResourceProcessor/LoggingSetupRecorder due to lack of build items.

Also Quarkus core registers a global LogCleanupFilter after named handlers initialization, so we need to implement #setFilter rather as an #addFilter.