### PR TITLE
fix(ci): use a fixed tag for splunk/splunk image

### DIFF
--- a/integration-test/src/test/java/io/quarkiverse/logging/splunk/SplunkResource.java
+++ b/integration-test/src/test/java/io/quarkiverse/logging/splunk/SplunkResource.java
@@ -21,7 +21,7 @@ public class SplunkResource implements QuarkusTestResourceLifecycleManager {
     private static final Logger logger = LoggerFactory.getLogger(SplunkResource.class);
 
     private final GenericContainer splunk = new GenericContainer(
-            "splunk/splunk")
+            "splunk/splunk:9.2.0.1")
             .withExposedPorts(8000, 8088, 8089)
             .withEnv("SPLUNK_START_ARGS", "--accept-license")
             .withEnv("SPLUNK_PASSWORD", "admin123")


### PR DESCRIPTION
Attempt to fix https://github.com/quarkiverse/quarkiverse/issues/37 
Nightly builds started failing ~2 weeks ago, so using a tag that is older than that: https://hub.docker.com/layers/splunk/splunk/9.2.0.1/images/sha256-0b1c082353c4da2b6a2e01c8c8159b010a84f430d34fe3d4ea7e6039be90e525?context=explore