### PR TITLE
feat(quarkus): Migrate to Quarkus 3.15.1

### DIFF
--- a/deployment/src/test/java/io/quarkiverse/logging/splunk/AbstractMockServerTest.java
+++ b/deployment/src/test/java/io/quarkiverse/logging/splunk/AbstractMockServerTest.java
@@ -8,6 +8,7 @@ import static org.mockserver.model.HttpResponse.response;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.mockserver.configuration.ConfigurationProperties;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.ClearType;
 import org.mockserver.model.HttpRequest;
@@ -18,6 +19,8 @@ public abstract class AbstractMockServerTest {
 
     @BeforeAll
     public static void setUpOnce() {
+        ConfigurationProperties.dynamicallyCreateCertificateAuthorityCertificate(false);
+        ConfigurationProperties.assumeAllRequestsAreHttp(true);
         httpServer = ClientAndServer.startClientAndServer(8088);
         // This needs to be done as early as possible, so Quarkus startup logs don't fail to be sent
         httpServer

--- a/deployment/src/test/java/io/quarkiverse/logging/splunk/LoggingSplunkMandatoryConfigTest.java
+++ b/deployment/src/test/java/io/quarkiverse/logging/splunk/LoggingSplunkMandatoryConfigTest.java
@@ -21,6 +21,7 @@ class LoggingSplunkMandatoryConfigTest {
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
             .withConfigurationResource("application-splunk-logging-mandatory.properties")
             .assertException(e -> {
+                System.out.println(e.getMessage());
                 assertSame(IllegalArgumentException.class, e.getClass());
                 assertTrue(e.getMessage().contains("quarkus.log.handler.splunk.token"));
             });

--- a/docs/modules/ROOT/pages/includes/quarkus-log-handler-splunk.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-log-handler-splunk.adoc
@@ -1172,4 +1172,4 @@ In other cases, the simplified format is translated to the `java.time.Duration` 
 
 * If the value is a number followed by `h`, `m`, or `s`, it is prefixed with `PT`.
 * If the value is a number followed by `d`, it is prefixed with `P`.
-
+====

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkiverse</groupId>
     <artifactId>quarkiverse-parent</artifactId>
-    <version>16</version>
+    <version>18</version>
   </parent>
   <groupId>io.quarkiverse.logging.splunk</groupId>
   <artifactId>quarkus-logging-splunk-parent</artifactId>
@@ -36,7 +36,7 @@
     <maven.compiler.target>17</maven.compiler.target>
     <maven.compiler.release>17</maven.compiler.release>
     <maven.compiler.parameters>true</maven.compiler.parameters>
-    <quarkus.version>3.8.3</quarkus.version>
+    <quarkus.version>3.15.1</quarkus.version>
     <splunk.logging.version>1.11.8</splunk.logging.version>
     <!-- https://antoniogoncalves.org/2012/12/13/lets-turn-integration-tests-with-maven-to-a-first-class-citizen/ -->
     <skipTests>false</skipTests>

--- a/runtime/src/main/java/io/quarkiverse/logging/splunk/AsyncConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/splunk/AsyncConfig.java
@@ -2,30 +2,30 @@ package io.quarkiverse.logging.splunk;
 
 import org.jboss.logmanager.handlers.AsyncHandler;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithParentName;
 
 /**
  * Copy of io.quarkus.runtime.logging, as the fields are package-private.
  */
-@ConfigGroup
-public class AsyncConfig {
+public interface AsyncConfig {
 
     /**
      * Indicates whether to log asynchronously
      */
-    @ConfigItem(name = ConfigItem.PARENT)
-    boolean enable;
+    @WithDefault("false")
+    @WithParentName
+    boolean enable();
 
     /**
      * The queue length to use before flushing writing
      */
-    @ConfigItem(defaultValue = "512")
-    int queueLength;
+    @WithDefault("512")
+    int queueLength();
 
     /**
      * Determine whether to block the publisher (rather than drop the message) when the queue is full
      */
-    @ConfigItem(defaultValue = "block")
-    AsyncHandler.OverflowAction overflow;
+    @WithDefault("block")
+    AsyncHandler.OverflowAction overflow();
 }

--- a/runtime/src/main/java/io/quarkiverse/logging/splunk/DevServicesLoggingSplunkRuntimeConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/splunk/DevServicesLoggingSplunkRuntimeConfig.java
@@ -2,14 +2,9 @@ package io.quarkiverse.logging.splunk;
 
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
-
-@ConfigGroup
-public class DevServicesLoggingSplunkRuntimeConfig {
+public interface DevServicesLoggingSplunkRuntimeConfig {
     /**
      * The API URL the splunk dev service listens on.
      */
-    @ConfigItem
-    public Optional<String> apiUrl;
+    Optional<String> apiUrl();
 }

--- a/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkConfig.java
@@ -6,26 +6,32 @@ package io.quarkiverse.logging.splunk;
 
 import java.util.Map;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithParentName;
 
 /**
  * Configuration for Splunk HEC logging
  */
-@ConfigRoot(phase = ConfigPhase.RUN_TIME, name = "log.handler.splunk")
-public class SplunkConfig {
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+@ConfigMapping(prefix = "quarkus.log.handler.splunk")
+public interface SplunkConfig {
 
     /**
      * Configuration for Splunk HEC logging for the root level.
      */
-    @ConfigItem(name = ConfigItem.PARENT)
-    public SplunkHandlerConfig config;
+    @WithParentName
+    SplunkHandlerConfig config();
+
     /**
      * Map of all the custom/named handlers configuration using Splunk implementation.
      */
-    @ConfigItem(name = ConfigItem.PARENT)
-    public Map<String, SplunkHandlerConfig> namedHandlers;
+    @WithParentName
+    Map<String, SplunkHandlerConfig> namedHandlers();
 
-    public DevServicesLoggingSplunkRuntimeConfig devservices;
+    /**
+     * Runtime configuration for the Splunk DevService.
+     */
+    DevServicesLoggingSplunkRuntimeConfig devservices();
 }

--- a/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkHandlerConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkHandlerConfig.java
@@ -5,47 +5,29 @@ Contributor(s): Kevin Viet, Romain Quinio, Yohann Puyhaubert (Amadeus s.a.s.)
 package io.quarkiverse.logging.splunk;
 
 import java.time.Duration;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.BooleanSupplier;
 import java.util.logging.Level;
 
 import com.splunk.logging.HttpEventCollectorSender;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
 
 /**
  * The configuration of the Splunk root or any Splunk named handler.
  */
-@ConfigGroup
-public class SplunkHandlerConfig {
+public interface SplunkHandlerConfig {
     /**
      * Determine whether to enable the handler
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean enabled = true;
-
-    public static class Enabled implements BooleanSupplier {
-
-        final SplunkHandlerConfig config;
-
-        public Enabled(SplunkHandlerConfig config) {
-            this.config = config;
-        }
-
-        @Override
-        public boolean getAsBoolean() {
-            return config.enabled;
-        }
-    }
+    @WithDefault("true")
+    boolean enabled();
 
     /**
      * The splunk handler log level. By default, it is no more strict than the root handler level.
      */
-    @ConfigItem(defaultValue = "ALL")
-    public Level level = Level.ALL;
+    @WithDefault("ALL")
+    Level level();
 
     /**
      * Splunk HEC endpoint base url.
@@ -53,21 +35,20 @@ public class SplunkHandlerConfig {
      * With raw events, the endpoint targeted is /services/collector/raw.
      * With flat or nested JSON events, the endpoint targeted is /services/collector/event/1.0.
      */
-    @ConfigItem(defaultValue = "https://localhost:8088/")
-    public String url = "https://localhost:8088/";
+    @WithDefault("https://localhost:8088/")
+    String url();
 
     /**
      * Disable TLS certificate validation with HEC endpoint
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean disableCertificateValidation = false;
+    @WithDefault("false")
+    boolean disableCertificateValidation();
 
     /**
      * The application token to authenticate with HEC, the token is mandatory if the extension is enabled
      * https://docs.splunk.com/Documentation/Splunk/latest/Data/FormateventsforHTTPEventCollector#HEC_token
      */
-    @ConfigItem
-    public Optional<String> token;
+    Optional<String> token();
 
     /**
      * The strategy to send events to HEC.
@@ -78,48 +59,51 @@ public class SplunkHandlerConfig {
      * timestamp
      * (that has 1 millisecond resolution) may be indexed out of order by Splunk.
      */
-    @ConfigItem(defaultValue = "sequential")
-    public SendMode sendMode = SendMode.SEQUENTIAL;
+    @WithDefault("sequential")
+    SendMode sendMode();
 
     /**
      * A GUID to identify an HEC client and guarantee isolation at HEC level in case of slow clients.
-     * https://docs.splunk.com/Documentation/Splunk/latest/Data/AboutHECIDXAck#About_channels_and_sending_data
+     *
+     * @see <a href=
+     *      "https://docs.splunk.com/Documentation/Splunk/latest/Data/AboutHECIDXAck#About_channels_and_sending_data">splunk
+     *      guide</a>
      */
-    @ConfigItem
-    public Optional<String> channel;
+    Optional<String> channel();
 
     /**
      * Batching delay before sending a group of events.
+     * <p>
      * If 0, the events are sent immediately.
+     * </p>
      */
-    @ConfigItem(defaultValue = "10s")
-    public Duration batchInterval = Duration.ofSeconds(10);
+    @WithDefault("10s")
+    Duration batchInterval();
 
     /**
      * Maximum number of events in a batch. By default 10, if 0 no batching.
      */
-    @ConfigItem(defaultValue = "10")
-    public long batchSizeCount = 10;
+    @WithDefault("10")
+    long batchSizeCount();
 
     /**
      * Maximum total size in bytes of events in a batch. By default 10KB, if 0 no batching.
      */
-    @ConfigItem(defaultValue = "10240")
-    public long batchSizeBytes = 10 * 1024;
+    @WithDefault("10240")
+    long batchSizeBytes();
 
     /**
      * Maximum number of retries in case of I/O exceptions with HEC connection.
      */
-    @ConfigItem(defaultValue = "0")
-    public long maxRetries = 0;
+    @WithDefault("0")
+    long maxRetries();
 
     /**
      * A middleware to customize the behavior of sending events to Splunk.
      *
      * @see com.splunk.logging.HttpEventCollectorMiddleware
      */
-    @ConfigItem
-    public Optional<String> middleware;
+    Optional<String> middleware();
 
     /**
      * The log format, defining which metadata are inlined inside the log main payload.
@@ -127,78 +111,93 @@ public class SplunkHandlerConfig {
      * Specific metadata (hostname, category, thread name, ...), as well as MDC key/value map, can also be sent in a structured
      * way.
      */
-    @ConfigItem(defaultValue = "%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{3.}] (%t) %s%e%n")
-    public String format = "%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{3.}] (%t) %s%e%n";
+    @WithDefault("%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{3.}] (%t) %s%e%n")
+    String format();
 
     /**
      * Whether to send the thrown exception message as a structured metadata of the log event (as opposed to %e in a formatted
      * message, it does not include the exception name or stacktrace).
      * Only applicable to 'nested' serialization.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean includeException = false;
+    @WithDefault("false")
+    boolean includeException();
 
     /**
      * Whether to send the logger name as a structured metadata of the log event (equivalent of %c in a formatted message).
      * Only applicable to 'nested' serialization.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean includeLoggerName = false;
+    @WithDefault("false")
+    boolean includeLoggerName();
 
     /**
      * Whether to send the thread name as a structured metadata of the log event (equivalent of %t in a formatted message).
      * Only applicable to 'nested' serialization.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean includeThreadName = false;
+    @WithDefault("false")
+    boolean includeThreadName();
 
     /**
      * Overrides the host name metadata value.
+     * <p>
+     * Default value: the equivalent of %h in a formatted message.
+     * </p>
      */
-    @ConfigItem(defaultValueDocumentation = "The equivalent of %h in a formatted message")
-    public Optional<String> metadataHost;
+    Optional<String> metadataHost();
 
     /**
      * The source value to assign to the event data. For example, if you're sending data from an app you're developing,
      * you could set this key to the name of the app.
-     * https://docs.splunk.com/Documentation/Splunk/latest/Data/FormateventsforHTTPEventCollector#Event_metadata
+     *
+     * @see <a href=
+     *      "https://docs.splunk.com/Documentation/Splunk/latest/Data/FormateventsforHTTPEventCollector#Event_metadata">splunk
+     *      guide</a>
      */
-    @ConfigItem
-    public Optional<String> metadataSource;
+    Optional<String> metadataSource();
 
     /**
      * The optional format of the events, to enable some parsing on Splunk side.
-     * https://docs.splunk.com/Documentation/Splunk/latest/Data/FormateventsforHTTPEventCollector#Event_metadata
+     *
      * <p>
      * A given source type may have indexed fields extraction enabled, which is the case of the built-in _json used for nested
      * serialization.
+     * </p>
+     * <p>
+     * Default value: _json for nested serialization, not set otherwise
+     * </p>
+     *
+     * @see <a href=
+     *      "https://docs.splunk.com/Documentation/Splunk/latest/Data/FormateventsforHTTPEventCollector#Event_metadata">splunk
+     *      guide</a>
      */
-    @ConfigItem(defaultValueDocumentation = "_json for nested serialization, not set otherwise")
-    public Optional<String> metadataSourceType;
+    Optional<String> metadataSourceType();
 
     /**
      * The optional name of the index by which the event data is to be stored. If set, it must be within the
      * list of allowed indexes of the token (if it has the indexes parameter set).
-     * https://docs.splunk.com/Documentation/Splunk/latest/Data/FormateventsforHTTPEventCollector#Event_metadata
+     *
+     * @see <a href=
+     *      "https://docs.splunk.com/Documentation/Splunk/latest/Data/FormateventsforHTTPEventCollector#Event_metadata">splunk
+     *      guide</a>
      */
-    @ConfigItem
-    public Optional<String> metadataIndex;
+    Optional<String> metadataIndex();
 
     /**
      * Optional static key/value pairs to populate the "fields" key of event metadata. This isn't
      * applicable to raw serialization.
-     * https://docs.splunk.com/Documentation/Splunk/latest/Data/FormateventsforHTTPEventCollector#Event_metadata
+     *
+     * @see <a href=
+     *      "https://docs.splunk.com/Documentation/Splunk/latest/Data/FormateventsforHTTPEventCollector#Event_metadata">splunk
+     *      guide</a>
      */
-    @ConfigItem
-    public Map<String, String> metadataFields = new HashMap<>();
+    Map<String, String> metadataFields();
 
     /**
      * The name of the key used to convey the severity / log level in the metadata fields.
      * Only applicable to 'flat' serialization.
      * With 'nested' serialization, there is already a 'severity' field.
      */
-    @ConfigItem(defaultValue = "severity")
-    public String metadataSeverityFieldName = "severity";
+    @WithDefault("severity")
+    String metadataSeverityFieldName();
 
     /**
      * Determines whether the events are sent in raw mode. In case the raw event (i.e. the actual log message)
@@ -208,8 +207,8 @@ public class SplunkHandlerConfig {
      * @deprecated Use {@link #serialization}
      */
     @Deprecated(forRemoval = true)
-    @ConfigItem(defaultValue = "false")
-    public boolean raw = false;
+    @WithDefault("false")
+    boolean raw();
 
     /**
      * The format of the payload.
@@ -222,32 +221,30 @@ public class SplunkHandlerConfig {
      * 'fields' root object.
      * </ul>
      */
-    @ConfigItem(defaultValue = "nested")
-    public SerializationFormat serialization = SerializationFormat.NESTED;
+    @WithDefault("nested")
+    SerializationFormat serialization();
 
     /**
      * The name of the named filter to link to the splunk handler.
      */
-    @ConfigItem
-    public Optional<String> filter;
+    Optional<String> filter();
 
     /**
      * AsyncHandler config
      * <p>
      * This is independent of the SendMode, i.e. whether the HTTP client is async or not.
      */
-    @ConfigItem
-    AsyncConfig async;
+    AsyncConfig async();
 
     /**
      * Mirrors com.splunk.logging.HttpEventCollectorSender.SendMode
      */
-    public enum SendMode {
+    enum SendMode {
         SEQUENTIAL,
         PARALLEL
     }
 
-    public enum SerializationFormat {
+    enum SerializationFormat {
         RAW,
         NESTED,
         FLAT
@@ -256,30 +253,30 @@ public class SplunkHandlerConfig {
     /**
      * Sets the default connect timeout for new connections in milliseconds.
      */
-    @ConfigItem(defaultValue = "3000")
-    public long connectTimeout = HttpEventCollectorSender.TimeoutSettings.DEFAULT_CONNECT_TIMEOUT;
+    @WithDefault("3000")
+    long connectTimeout();
 
     /**
      * Sets the default timeout for complete calls in milliseconds.
      */
-    @ConfigItem(defaultValue = "0")
-    public long callTimeout = HttpEventCollectorSender.TimeoutSettings.DEFAULT_CALL_TIMEOUT;
+    @WithDefault("0")
+    long callTimeout();
 
     /**
      * Sets the default read timeout for new connections in milliseconds.
      */
-    @ConfigItem(defaultValue = "10000")
-    public long readTimeout = HttpEventCollectorSender.TimeoutSettings.DEFAULT_READ_TIMEOUT;
+    @WithDefault("10000")
+    long readTimeout();
 
     /**
      * Sets the default write timeout for new connections in milliseconds.
      */
-    @ConfigItem(defaultValue = "10000")
-    public long writeTimeout = HttpEventCollectorSender.TimeoutSettings.DEFAULT_WRITE_TIMEOUT;
+    @WithDefault("10000")
+    long writeTimeout();
 
     /**
      * Sets the default termination timeout during a flush in milliseconds.
      */
-    @ConfigItem(defaultValue = "0")
-    public long terminationTimeout = HttpEventCollectorSender.TimeoutSettings.DEFAULT_TERMINATION_TIMEOUT;
+    @WithDefault("0")
+    long terminationTimeout();
 }

--- a/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkLogHandlerRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkLogHandlerRecorder.java
@@ -34,24 +34,25 @@ public class SplunkLogHandlerRecorder {
 
     public RuntimeValue<Optional<Handler>> initializeHandler(SplunkConfig rootConfig,
             DiscoveredLogComponents discoveredLogComponents) {
-        if (!rootConfig.config.enabled) {
+        if (!rootConfig.config().enabled()) {
             return new RuntimeValue<>(Optional.empty());
         }
 
-        Handler handler = buildHandlerFromConfig(rootConfig.config, discoveredLogComponents);
+        Handler handler = buildHandlerFromConfig(rootConfig.config(), discoveredLogComponents);
         return new RuntimeValue<>(Optional.of(handler));
     }
 
     public RuntimeValue<Map<String, Handler>> initializeHandlers(SplunkConfig rootConfig,
             DiscoveredLogComponents discoveredLogComponents) {
-        if (rootConfig.namedHandlers == null || rootConfig.namedHandlers.isEmpty()) {
+        if (rootConfig.namedHandlers() == null || rootConfig.namedHandlers().isEmpty()) {
             return new RuntimeValue<>(Collections.EMPTY_MAP);
         }
 
-        Map<String, Handler> namedHandlers = rootConfig.namedHandlers
+        Map<String, Handler> namedHandlers = rootConfig.namedHandlers()
                 .entrySet()
                 .stream()
-                .filter(e -> e.getValue().enabled)
+                .filter(e -> !"devservices".equals(e.getKey()))
+                .filter(e -> e.getValue().enabled())
                 .collect(Collectors.toMap(
                         e -> e.getKey(),
                         e -> buildHandlerFromConfig(e.getValue(), discoveredLogComponents)));
@@ -60,64 +61,62 @@ public class SplunkLogHandlerRecorder {
     }
 
     private Handler buildHandlerFromConfig(SplunkHandlerConfig config, DiscoveredLogComponents discoveredLogComponents) {
-        if (!config.token.isPresent()) {
+        if (!config.token().isPresent()) {
             throw new IllegalArgumentException("The property quarkus.log.handler.splunk.token is mandatory");
         }
         HttpEventCollectorSender sender = createSender(config);
         SplunkLogHandler splunkLogHandler = createSplunkLogHandler(sender, config);
-        splunkLogHandler.setLevel(config.level);
+        splunkLogHandler.setLevel(config.level());
         splunkLogHandler.setFormatter(
-                new PatternFormatter(config.format));
-        applyFilter(discoveredLogComponents, config.filter, splunkLogHandler);
+                new PatternFormatter(config.format()));
+        applyFilter(discoveredLogComponents, config.filter(), splunkLogHandler);
 
-        Handler handler = config.async.enable
-                ? createAsyncHandler(config.async,
-                        config.level, splunkLogHandler)
+        return config.async().enable()
+                ? createAsyncHandler(config.async(), config.level(), splunkLogHandler)
                 : splunkLogHandler;
-        return handler;
     }
 
     static HttpEventCollectorSender createSender(SplunkHandlerConfig config) {
         HttpEventCollectorErrorHandler.onError(new SplunkErrorCallback());
         String type = "";
-        if (config.raw || config.serialization == SplunkHandlerConfig.SerializationFormat.RAW) {
+        if (config.raw() || config.serialization() == SplunkHandlerConfig.SerializationFormat.RAW) {
             type = "Raw";
         }
 
         HttpEventCollectorSender.TimeoutSettings rto = null;
-        if ((config.connectTimeout != HttpEventCollectorSender.TimeoutSettings.DEFAULT_CONNECT_TIMEOUT)
-                || (config.callTimeout != HttpEventCollectorSender.TimeoutSettings.DEFAULT_CALL_TIMEOUT) ||
-                (config.readTimeout != HttpEventCollectorSender.TimeoutSettings.DEFAULT_READ_TIMEOUT)
-                || (config.writeTimeout != HttpEventCollectorSender.TimeoutSettings.DEFAULT_WRITE_TIMEOUT) ||
-                (config.terminationTimeout != HttpEventCollectorSender.TimeoutSettings.DEFAULT_TERMINATION_TIMEOUT)) {
-            rto = new HttpEventCollectorSender.TimeoutSettings(config.connectTimeout, config.callTimeout,
-                    config.readTimeout, config.writeTimeout, config.terminationTimeout);
+        if ((config.connectTimeout() != HttpEventCollectorSender.TimeoutSettings.DEFAULT_CONNECT_TIMEOUT)
+                || (config.callTimeout() != HttpEventCollectorSender.TimeoutSettings.DEFAULT_CALL_TIMEOUT) ||
+                (config.readTimeout() != HttpEventCollectorSender.TimeoutSettings.DEFAULT_READ_TIMEOUT)
+                || (config.writeTimeout() != HttpEventCollectorSender.TimeoutSettings.DEFAULT_WRITE_TIMEOUT) ||
+                (config.terminationTimeout() != HttpEventCollectorSender.TimeoutSettings.DEFAULT_TERMINATION_TIMEOUT)) {
+            rto = new HttpEventCollectorSender.TimeoutSettings(config.connectTimeout(), config.callTimeout(),
+                    config.readTimeout(), config.writeTimeout(), config.terminationTimeout());
         }
         // Timeout settings is not used and passing a null is correct regarding the code
         HttpEventCollectorSender sender = new HttpEventCollectorSender(
-                config.url,
-                config.token.get(),
-                config.channel.orElse(""),
+                config.url(),
+                config.token().get(),
+                config.channel().orElse(""),
                 type,
-                config.batchInterval.toMillis(),
-                config.batchSizeCount,
-                config.batchSizeBytes,
-                config.sendMode.name().toLowerCase(),
+                config.batchInterval().toMillis(),
+                config.batchSizeCount(),
+                config.batchSizeBytes(),
+                config.sendMode().name().toLowerCase(),
                 buildMetadata(config), rto);
-        if (config.serialization == SplunkHandlerConfig.SerializationFormat.FLAT) {
-            SplunkFlatEventSerializer serializer = new SplunkFlatEventSerializer(config.metadataSeverityFieldName);
+        if (config.serialization() == SplunkHandlerConfig.SerializationFormat.FLAT) {
+            SplunkFlatEventSerializer serializer = new SplunkFlatEventSerializer(config.metadataSeverityFieldName());
             sender.setEventHeaderSerializer(serializer);
             sender.setEventBodySerializer(serializer);
         }
-        if (config.middleware.isPresent()) {
+        if (config.middleware().isPresent()) {
             try {
                 sender.addMiddleware(
-                        Thread.currentThread().getContextClassLoader().loadClass(config.middleware.get())
+                        Thread.currentThread().getContextClassLoader().loadClass(config.middleware().get())
                                 .asSubclass(HttpSenderMiddleware.class)
                                 .getDeclaredConstructor()
                                 .newInstance());
             } catch (Exception e) {
-                throw new IllegalArgumentException("Could not instantiate middleware " + config.middleware.get(), e);
+                throw new IllegalArgumentException("Could not instantiate middleware " + config.middleware().get(), e);
             }
         }
         return sender;
@@ -126,38 +125,38 @@ public class SplunkLogHandlerRecorder {
     static Map<String, String> buildMetadata(SplunkHandlerConfig config) {
         HashMap<String, String> metadata = new HashMap<>();
         // Note: sending an empty index is invalid, the index property has to be omitted
-        config.metadataIndex.ifPresent(s -> metadata.put(MetadataTags.INDEX, s));
+        config.metadataIndex().ifPresent(s -> metadata.put(MetadataTags.INDEX, s));
         try {
             String hostName = InetAddress.getLocalHost().getHostName();
-            metadata.put(MetadataTags.HOST, config.metadataHost.orElse(hostName));
+            metadata.put(MetadataTags.HOST, config.metadataHost().orElse(hostName));
         } catch (UnknownHostException e) {
             // Ignore
         }
-        config.metadataSource.ifPresent(s -> metadata.put(MetadataTags.SOURCE, s));
+        config.metadataSource().ifPresent(s -> metadata.put(MetadataTags.SOURCE, s));
 
-        if (config.metadataSourceType.isPresent()) {
-            metadata.put(MetadataTags.SOURCETYPE, config.metadataSourceType.get());
-        } else if (config.serialization == SplunkHandlerConfig.SerializationFormat.NESTED) {
+        if (config.metadataSourceType().isPresent()) {
+            metadata.put(MetadataTags.SOURCETYPE, config.metadataSourceType().get());
+        } else if (config.serialization() == SplunkHandlerConfig.SerializationFormat.NESTED) {
             metadata.put(MetadataTags.SOURCETYPE, "_json");
         }
 
-        metadata.putAll(config.metadataFields);
+        metadata.putAll(config.metadataFields());
         return metadata;
     }
 
     private SplunkLogHandler createSplunkLogHandler(HttpEventCollectorSender sender,
             SplunkHandlerConfig config) {
         return new SplunkLogHandler(sender,
-                config.includeException,
-                config.includeLoggerName,
-                config.includeThreadName,
-                config.disableCertificateValidation,
-                config.maxRetries);
+                config.includeException(),
+                config.includeLoggerName(),
+                config.includeThreadName(),
+                config.disableCertificateValidation(),
+                config.maxRetries());
     }
 
     private static AsyncHandler createAsyncHandler(AsyncConfig asyncConfig, Level level, Handler handler) {
-        final AsyncHandler asyncHandler = new AsyncHandler(asyncConfig.queueLength);
-        asyncHandler.setOverflowAction(asyncConfig.overflow);
+        final AsyncHandler asyncHandler = new AsyncHandler(asyncConfig.queueLength());
+        asyncHandler.setOverflowAction(asyncConfig.overflow());
         asyncHandler.addHandler(handler);
         asyncHandler.setLevel(level);
         return asyncHandler;

--- a/runtime/src/main/java/io/quarkiverse/logging/splunk/config/build/DevServicesLoggingSplunkBuildTimeConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/splunk/config/build/DevServicesLoggingSplunkBuildTimeConfig.java
@@ -3,37 +3,33 @@ package io.quarkiverse.logging.splunk.config.build;
 import java.util.Map;
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
 
 /**
  * The build time configuration around the Splunk dev services.
  */
-@ConfigGroup
-public class DevServicesLoggingSplunkBuildTimeConfig {
+public interface DevServicesLoggingSplunkBuildTimeConfig {
     /**
      * whether to activate dev services or not
      */
-    @ConfigItem
-    public Optional<Boolean> enabled = Optional.empty();
+    @WithDefault("false")
+    boolean enabled();
 
     /**
      * Override the docker image used for the Splunk dev service
      */
-    @ConfigItem
-    public Optional<String> imageName;
+    Optional<String> imageName();
 
     /**
      * Whether the instance of splunk can be shared between runs in DEV mode.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean shared;
+    @WithDefault("true")
+    boolean shared();
 
     /**
      * Additional environment variables to inject.
      */
-    @ConfigItem
-    public Map<String, String> containerEnv;
+    Map<String, String> containerEnv();
 
     /**
      * Map that allows to tell to plug the following named handlers to the dev service
@@ -41,6 +37,5 @@ public class DevServicesLoggingSplunkBuildTimeConfig {
      * It is necessary as we do not have access to runtime configuration when starting the Splunk container.
      * </p>
      */
-    @ConfigItem
-    public Map<String, Boolean> plugNamedHandlers;
+    Map<String, Boolean> plugNamedHandlers();
 }

--- a/runtime/src/main/java/io/quarkiverse/logging/splunk/config/build/SplunkBuildConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/splunk/config/build/SplunkBuildConfig.java
@@ -1,17 +1,17 @@
 package io.quarkiverse.logging.splunk.config.build;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
 
 /**
  * The build time configuration for the Splunk logging extension.
  */
-@ConfigRoot(name = "log.handler.splunk", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
-public class SplunkBuildConfig {
+@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+@ConfigMapping(prefix = "quarkus.log.handler.splunk")
+public interface SplunkBuildConfig {
     /**
      * Configuration for the dev services.
      */
-    @ConfigItem
-    public DevServicesLoggingSplunkBuildTimeConfig devservices;
+    DevServicesLoggingSplunkBuildTimeConfig devservices();
 }

--- a/runtime/src/test/java/io/quarkiverse/logging/splunk/SplunkLogHandlerRecorderTest.java
+++ b/runtime/src/test/java/io/quarkiverse/logging/splunk/SplunkLogHandlerRecorderTest.java
@@ -2,8 +2,12 @@ package io.quarkiverse.logging.splunk;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.time.Duration;
 import java.util.Optional;
+import java.util.logging.Level;
 
 import org.junit.jupiter.api.Test;
 
@@ -15,7 +19,7 @@ class SplunkLogHandlerRecorderTest {
     void shouldSetupSenderWithConfiguredMiddleware() {
         // Arrange
         SplunkHandlerConfig config = createConfig();
-        config.middleware = Optional.of(TestMiddleware.class.getName());
+        when(config.middleware()).thenReturn(Optional.of(TestMiddleware.class.getName()));
 
         // Act
         HttpEventCollectorSender sender = SplunkLogHandlerRecorder.createSender(config);
@@ -32,7 +36,7 @@ class SplunkLogHandlerRecorderTest {
     void shouldThrowIfMiddlewareIsNotInstantiable() {
         // Arrange
         SplunkHandlerConfig config = createConfig();
-        config.middleware = Optional.of("NonExistentMiddleware");
+        when(config.middleware()).thenReturn(Optional.of("NonExistentMiddleware"));
 
         // Act & Assert
         assertThrows(IllegalArgumentException.class, () -> SplunkLogHandlerRecorder.createSender(config));
@@ -42,20 +46,44 @@ class SplunkLogHandlerRecorderTest {
     void shouldThrowIfMiddlewareIsNotOfCorrectType() {
         // Arrange
         SplunkHandlerConfig config = createConfig();
-        config.middleware = Optional.of(Object.class.getName());
+        when(config.middleware()).thenReturn(Optional.of(Object.class.getName()));
 
         // Act & Assert
         assertThrows(IllegalArgumentException.class, () -> SplunkLogHandlerRecorder.createSender(config));
     }
 
     private SplunkHandlerConfig createConfig() {
-        SplunkHandlerConfig config = new SplunkHandlerConfig();
-        config.token = Optional.of("token");
-        config.channel = Optional.empty();
-        config.metadataIndex = Optional.empty();
-        config.metadataHost = Optional.empty();
-        config.metadataSource = Optional.empty();
-        config.metadataSourceType = Optional.empty();
+        SplunkHandlerConfig config = mock(SplunkHandlerConfig.class);
+        when(config.token()).thenReturn(Optional.of("token"));
+        when(config.channel()).thenReturn(Optional.empty());
+        when(config.metadataIndex()).thenReturn(Optional.empty());
+        when(config.metadataHost()).thenReturn(Optional.empty());
+        when(config.metadataSource()).thenReturn(Optional.empty());
+        when(config.metadataSourceType()).thenReturn(Optional.empty());
+
+        // override with default values
+        when(config.enabled()).thenReturn(true);
+        when(config.level()).thenReturn(Level.ALL);
+        when(config.url()).thenReturn("https://localhost:8088/");
+        when(config.disableCertificateValidation()).thenReturn(false);
+        when(config.sendMode()).thenReturn(SplunkHandlerConfig.SendMode.SEQUENTIAL);
+        when(config.batchInterval()).thenReturn(Duration.ofSeconds(10));
+        when(config.batchSizeCount()).thenReturn(10L);
+        when(config.batchSizeBytes()).thenReturn(10240L);
+        when(config.maxRetries()).thenReturn(0L);
+        when(config.format()).thenReturn("%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{3.}] (%t) %s%e%n");
+        when(config.includeException()).thenReturn(false);
+        when(config.includeLoggerName()).thenReturn(false);
+        when(config.includeThreadName()).thenReturn(false);
+        when(config.metadataSeverityFieldName()).thenReturn("severity");
+        when(config.serialization()).thenReturn(SplunkHandlerConfig.SerializationFormat.NESTED);
+        when(config.connectTimeout()).thenReturn(3000L);
+        when(config.callTimeout()).thenReturn(0L);
+        when(config.readTimeout()).thenReturn(10000L);
+        when(config.writeTimeout()).thenReturn(10000L);
+        when(config.terminationTimeout()).thenReturn(0L);
+
         return config;
     }
+
 }

--- a/test-utils/src/test/java/io/quarkiverse/logging/splunk/test/LoggingSplunkInjectingTestResourceTest.java
+++ b/test-utils/src/test/java/io/quarkiverse/logging/splunk/test/LoggingSplunkInjectingTestResourceTest.java
@@ -22,10 +22,10 @@ class LoggingSplunkInjectingTestResourceTest {
 
     LoggingSplunkInjectingTestResource resource = new LoggingSplunkInjectingTestResource();
 
-  @BeforeEach
-  void setUp() {
-    when(context.devServicesProperties()).thenReturn(Map.of());
-  }
+    @BeforeEach
+    void setUp() {
+        when(context.devServicesProperties()).thenReturn(Map.of());
+    }
 
     @Test
     void disabled() {
@@ -38,31 +38,31 @@ class LoggingSplunkInjectingTestResourceTest {
         assertThat(testInstance.splunkHandlerUrl, nullValue());
     }
 
-  @Test
-   void enabled() {
-     when(context.devServicesProperties()).thenReturn(Map.of("quarkus.log.handler.splunk.url",
-         "http://localhost:8088", "quarkus.log.handler.splunk.devservices.api-url", "http://localhost:8089"));
-    FieldWithAnnotation testInstance = new FieldWithAnnotation();
+    @Test
+    void enabled() {
+        when(context.devServicesProperties()).thenReturn(Map.of("quarkus.log.handler.splunk.url",
+                "http://localhost:8088", "quarkus.log.handler.splunk.devservices.api-url", "http://localhost:8089"));
+        FieldWithAnnotation testInstance = new FieldWithAnnotation();
 
-     resource.setIntegrationTestContext(context);
-     resource.inject(testInstance);
+        resource.setIntegrationTestContext(context);
+        resource.inject(testInstance);
 
-     assertThat(testInstance.splunkApiUrl, equalTo("http://localhost:8089"));
-     assertThat(testInstance.splunkHandlerUrl, equalTo("http://localhost:8088"));
-   }
+        assertThat(testInstance.splunkApiUrl, equalTo("http://localhost:8089"));
+        assertThat(testInstance.splunkHandlerUrl, equalTo("http://localhost:8088"));
+    }
 
-  @Test
-  void noAnnotationORWrongType() {
-    when(context.devServicesProperties()).thenReturn(Map.of("quarkus.log.handler.splunk.url",
-        "http://localhost:8088", "quarkus.log.handler.splunk.devservices.api-url", "http://localhost:8089"));
-    FieldWithNoAnnotation testInstance = new FieldWithNoAnnotation();
+    @Test
+    void noAnnotationORWrongType() {
+        when(context.devServicesProperties()).thenReturn(Map.of("quarkus.log.handler.splunk.url",
+                "http://localhost:8088", "quarkus.log.handler.splunk.devservices.api-url", "http://localhost:8089"));
+        FieldWithNoAnnotation testInstance = new FieldWithNoAnnotation();
 
-    resource.setIntegrationTestContext(context);
-    resource.inject(testInstance);
+        resource.setIntegrationTestContext(context);
+        resource.inject(testInstance);
 
-    assertThat(testInstance.splunkApiUrl, nullValue());
-    assertThat(testInstance.splunkHandlerUrl, nullValue());
-  }
+        assertThat(testInstance.splunkApiUrl, nullValue());
+        assertThat(testInstance.splunkHandlerUrl, nullValue());
+    }
 
     public static class NoFields {
 


### PR DESCRIPTION
Also update quarkiverse-parent to version 18.

Consequences:

* ConfigRoot needed to be migrated to ConfigMapping with transformation in interfaces. Update everywhere the configuration mapping is used with method calls.

Biggest impact was on named handlers, the devservices entry where considered as a key of the named handlers map. A filtering had to be added in SplunkLogHandlerRecorder.

There are no breaking changes.