### PR TITLE
Fix typo in documentation: By default quarkus.log.handler.splunk.asyn…

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -232,7 +232,7 @@ end
 end
 ....
 
-By default `quarkus.log.handler.splunk.async.queue-length=block`, so applicative threads will block once the queue limit has reached `quarkus.log.handler.splunk.async.queue-length`.
+By default `quarkus.log.handler.splunk.async.overflow=block`, so applicative threads will block once the queue limit has reached `quarkus.log.handler.splunk.async.queue-length`.
 
 There's no link between `quarkus.log.handler.splunk.async.queue-length` and `quarkus.log.handler.splunk.batch-size-count`.
 


### PR DESCRIPTION
Fix small typo in documentation.
The documentation indicated the property `quarkus.log.handler.splunk.async.queue-length` to have the default value `block` instead of the property `quarkus.log.handle.splunk.async.overflow`