### PR TITLE
ci: add back central repo for efficiency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,9 +56,20 @@
   </modules>
   <repositories>
     <repository>
+      <id>central</id>
+      <name>Central Repository</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+    <repository>
       <id>splunk</id>
       <name>Splunk Releases</name>
       <url>https://splunk.jfrog.io/splunk/ext-releases-local</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
     </repository>
   </repositories>
   <dependencyManagement>


### PR DESCRIPTION
When adding a custom repository, central repo inherited from Maven parent is tried last, instead of first. This causes builds to be slower, as most dependencies are resolved via central.

cf https://github.com/quarkiverse/quarkus-logging-splunk/issues/293#issuecomment-2437537429