### PR TITLE
Disable AsyncHandler autoflush with batch delay

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
       shell: bash
     - name: Cache Maven Repository
       id: cache-maven
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         # refresh cache every month to avoid unlimited growth

--- a/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkLogHandler.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkLogHandler.java
@@ -60,6 +60,12 @@ public class SplunkLogHandler extends ExtHandler {
                 null);
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Warning: explicit calls to flush bypass event batching checks, so events are sent too early. Do not rely on APIs
+     * calling flush directly, like the AsyncHandler's autoflush mechanism.
+     */
     @Override
     public void flush() {
         this.sender.flush();

--- a/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkLogHandlerRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkLogHandlerRecorder.java
@@ -144,7 +144,7 @@ public class SplunkLogHandlerRecorder {
         return metadata;
     }
 
-    private SplunkLogHandler createSplunkLogHandler(HttpEventCollectorSender sender,
+    private static SplunkLogHandler createSplunkLogHandler(HttpEventCollectorSender sender,
             SplunkHandlerConfig config) {
         return new SplunkLogHandler(sender,
                 config.includeException(),
@@ -159,6 +159,8 @@ public class SplunkLogHandlerRecorder {
         asyncHandler.setOverflowAction(asyncConfig.overflow());
         asyncHandler.addHandler(handler);
         asyncHandler.setLevel(level);
+        // autoflush ignores event batch configuration and sends events immediately, disable it
+        asyncHandler.setAutoFlush(false);
         return asyncHandler;
     }
 

--- a/runtime/src/test/java/io/quarkiverse/logging/splunk/SplunkLogHandlerRecorderTest.java
+++ b/runtime/src/test/java/io/quarkiverse/logging/splunk/SplunkLogHandlerRecorderTest.java
@@ -7,11 +7,15 @@ import static org.mockito.Mockito.when;
 
 import java.time.Duration;
 import java.util.Optional;
+import java.util.logging.Handler;
 import java.util.logging.Level;
 
+import org.jboss.logmanager.handlers.AsyncHandler;
 import org.junit.jupiter.api.Test;
 
 import com.splunk.logging.HttpEventCollectorSender;
+
+import io.quarkus.runtime.RuntimeValue;
 
 class SplunkLogHandlerRecorderTest {
 
@@ -52,6 +56,20 @@ class SplunkLogHandlerRecorderTest {
         assertThrows(IllegalArgumentException.class, () -> SplunkLogHandlerRecorder.createSender(config));
     }
 
+    @Test
+    void shouldCreateAsyncHandlerWithoutAutoflush() {
+        // Arrange
+        SplunkConfig rootConfig = createAsyncRootConfig();
+
+        // Act
+        RuntimeValue<Optional<Handler>> handler = new SplunkLogHandlerRecorder().initializeHandler(rootConfig, null);
+
+        // Assert
+        assertTrue(handler.getValue().isPresent());
+        AsyncHandler asyncHandler = assertInstanceOf(AsyncHandler.class, handler.getValue().get());
+        assertFalse(asyncHandler.isAutoFlush());
+    }
+
     private SplunkHandlerConfig createConfig() {
         SplunkHandlerConfig config = mock(SplunkHandlerConfig.class);
         when(config.token()).thenReturn(Optional.of("token"));
@@ -84,6 +102,25 @@ class SplunkLogHandlerRecorderTest {
         when(config.terminationTimeout()).thenReturn(0L);
 
         return config;
+    }
+
+    private SplunkConfig createAsyncRootConfig() {
+        SplunkHandlerConfig handlerConfig = createConfig();
+        when(handlerConfig.middleware()).thenReturn(Optional.of(TestMiddleware.class.getName()));
+        // Override batchInterval duration
+        when(handlerConfig.batchInterval()).thenReturn(Duration.ofSeconds(10));
+
+        SplunkConfig rootConfig = mock(SplunkConfig.class);
+        when(rootConfig.config()).thenReturn(handlerConfig);
+
+        // Enable async
+        AsyncConfig asyncConfig = mock(AsyncConfig.class);
+        when(asyncConfig.enable()).thenReturn(true);
+        when(asyncConfig.queueLength()).thenReturn(512);
+        when(asyncConfig.overflow()).thenReturn(AsyncHandler.OverflowAction.BLOCK);
+        when(handlerConfig.async()).thenReturn(asyncConfig);
+
+        return rootConfig;
     }
 
 }


### PR DESCRIPTION
This commit solves a discrepancy between blocking and async handlers, where the async handler would ignore any specified batchInterval due to the activation of autoflush by default.