### PR TITLE
fix: add new mandatory arg of splunk latest image

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/logging/splunk/SplunkContainer.java
+++ b/deployment/src/main/java/io/quarkiverse/logging/splunk/SplunkContainer.java
@@ -24,6 +24,7 @@ public class SplunkContainer extends GenericContainer<SplunkContainer> {
 
     public SplunkContainer(DockerImageName dockerImageName) {
         super(dockerImageName);
+        withEnv("SPLUNK_GENERAL_TERMS", "--accept-sgt-current-at-splunk-com");
         withEnv("SPLUNK_START_ARGS", "--accept-license");
         withEnv("SPLUNK_PASSWORD", SPLUNK_PASSWORD);
         withEnv("SPLUNK_HEC_TOKEN", HEC_TOKEN);


### PR DESCRIPTION
Splunk added a launch option to acknolwedge https://www.splunk.com/en_us/legal/splunk-general-terms.html
That's the problem of depending on :latest when there's a breaking change.
However the Splunk images also have an "expiration", so if we hardcode the tag, it will refuse to start after 6 months...

The fix impacts:

* The CI builds of this repo (seen via https://github.com/quarkiverse/quarkiverse/issues/37)
* The DevService => we'll need to release a patch.