### PR TITLE
fix: add option to disable printing log events to stdout

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-logging-splunk.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-logging-splunk.adoc
@@ -402,6 +402,29 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
+a| [[quarkus-logging-splunk_quarkus-log-handler-splunk-print-events-to-stdout-on-error]] [.property-path]##link:#quarkus-logging-splunk_quarkus-log-handler-splunk-print-events-to-stdout-on-error[`quarkus.log.handler.splunk.print-events-to-stdout-on-error`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.log.handler.splunk.print-events-to-stdout-on-error+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+
+Whether to log events that could not be sent to Splunk when a failure occurred (after retries)
+using the standard output of the process.
+Applications that deal with sensitive data may want to disable this.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_HANDLER_SPLUNK_PRINT_EVENTS_TO_STDOUT_ON_ERROR+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LOG_HANDLER_SPLUNK_PRINT_EVENTS_TO_STDOUT_ON_ERROR+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
 a| [[quarkus-logging-splunk_quarkus-log-handler-splunk-format]] [.property-path]##link:#quarkus-logging-splunk_quarkus-log-handler-splunk-format[`quarkus.log.handler.splunk.format`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.log.handler.splunk.format+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-logging-splunk_quarkus.log.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-logging-splunk_quarkus.log.adoc
@@ -381,26 +381,29 @@ endif::add-copy-button-to-env-var[]
 |long
 |`0`
 
-a| [[quarkus-logging-splunk_quarkus-log-handler-splunk-middleware]] [.property-path]##link:#quarkus-logging-splunk_quarkus-log-handler-splunk-middleware[`quarkus.log.handler.splunk.middleware`]##
+a| [[quarkus-logging-splunk_quarkus-log-handler-splunk-print-events-to-stdout-on-error]] [.property-path]##link:#quarkus-logging-splunk_quarkus-log-handler-splunk-print-events-to-stdout-on-error[`quarkus.log.handler.splunk.print-events-to-stdout-on-error`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.log.handler.splunk.middleware+++[]
+config_property_copy_button:+++quarkus.log.handler.splunk.print-events-to-stdout-on-error+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-A middleware to customize the behavior of sending events to Splunk.
+
+Whether to log events that could not be sent to Splunk when a failure occurred (after retries)
+using the standard output of the process.
+Applications that deal with sensitive data may want to disable this.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_HANDLER_SPLUNK_MIDDLEWARE+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_HANDLER_SPLUNK_PRINT_EVENTS_TO_STDOUT_ON_ERROR+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LOG_HANDLER_SPLUNK_MIDDLEWARE+++`
+Environment variable: `+++QUARKUS_LOG_HANDLER_SPLUNK_PRINT_EVENTS_TO_STDOUT_ON_ERROR+++`
 endif::add-copy-button-to-env-var[]
 --
-|string
-|
+|boolean
+|`true`
 
 a| [[quarkus-logging-splunk_quarkus-log-handler-splunk-format]] [.property-path]##link:#quarkus-logging-splunk_quarkus-log-handler-splunk-format[`quarkus.log.handler.splunk.format`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -142,6 +142,8 @@ Batched events that cannot be sent to the Splunk indexer will be logged to stdou
 * Formatted using console handler settings if the console handler is enabled
 * Formatted using splunk handler settings otherwise
 
+It is recommended to disable this feature for applications dealing with sensitive data, as logs might contain sensitive information.
+
 In any case, the root cause of the failure is always logged to stderr.
 
 === Asynchronous handler

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -104,6 +104,11 @@
             <artifactId>asciidoctorj-diagram</artifactId>
             <version>3.0.1</version>
           </dependency>
+          <dependency>
+            <groupId>org.asciidoctor</groupId>
+            <artifactId>asciidoctorj-diagram-plantuml</artifactId>
+            <version>1.2025.3</version>
+          </dependency>
         </dependencies>
       </plugin>
     </plugins>

--- a/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkErrorCallback.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkErrorCallback.java
@@ -28,16 +28,19 @@ public class SplunkErrorCallback implements ErrorCallback {
 
     PrintStream stderr;
 
-    public SplunkErrorCallback() {
-        this(System.out, System.err); // NOSONAR
+    boolean printEventsToStdoutOnError;
+
+    public SplunkErrorCallback(boolean printEventsToStdoutOnError) {
+        this(System.out, System.err, printEventsToStdoutOnError); // NOSONAR
     }
 
     /**
      * For unit tests
      */
-    public SplunkErrorCallback(PrintStream stdout, PrintStream stderr) {
+    public SplunkErrorCallback(PrintStream stdout, PrintStream stderr, boolean printEventsToStdoutOnError) {
         this.stdout = stdout;
         this.stderr = stderr;
+        this.printEventsToStdoutOnError = printEventsToStdoutOnError;
     }
 
     /**
@@ -52,7 +55,7 @@ public class SplunkErrorCallback implements ErrorCallback {
         e.printStackTrace(new PrintWriter(stringWriter));
         this.stderr.println(stringWriter.toString());
 
-        if (!isConsoleHandlerEnabled()) {
+        if (printEventsToStdoutOnError && !isConsoleHandlerEnabled()) {
             for (HttpEventCollectorEventInfo logEvent : list) {
                 this.stdout.println(logEvent.getMessage());
             }

--- a/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkHandlerConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkHandlerConfig.java
@@ -106,6 +106,18 @@ public interface SplunkHandlerConfig {
     Optional<String> middleware();
 
     /**
+     * Whether to log events that could not be sent to Splunk when a failure occurred (after retries)
+     * using the standard output of the process.
+     * Applications that deal with sensitive data may want to disable this
+     *
+     * @see <a href=
+     *      "https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html#data-to-exclude">OWASP logging cheat
+     *      guide</a>
+     */
+    @WithDefault("true")
+    boolean printEventsToStdoutOnError();
+
+    /**
      * The log format, defining which metadata are inlined inside the log main payload.
      * <p>
      * Specific metadata (hostname, category, thread name, ...), as well as MDC key/value map, can also be sent in a structured

--- a/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkLogHandlerRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkLogHandlerRecorder.java
@@ -77,7 +77,7 @@ public class SplunkLogHandlerRecorder {
     }
 
     static HttpEventCollectorSender createSender(SplunkHandlerConfig config) {
-        HttpEventCollectorErrorHandler.onError(new SplunkErrorCallback());
+        HttpEventCollectorErrorHandler.onError(new SplunkErrorCallback(config.printEventsToStdoutOnError()));
         String type = "";
         if (config.raw() || config.serialization() == SplunkHandlerConfig.SerializationFormat.RAW) {
             type = "Raw";

--- a/runtime/src/test/java/io/quarkiverse/logging/splunk/SplunkErrorCallbackTest.java
+++ b/runtime/src/test/java/io/quarkiverse/logging/splunk/SplunkErrorCallbackTest.java
@@ -49,7 +49,7 @@ public class SplunkErrorCallbackTest {
 
     @Test
     public void splunkErrorShouldBeLoggedToStderr() {
-        SplunkErrorCallback callback = new SplunkErrorCallback(stdout, stderr);
+        SplunkErrorCallback callback = new SplunkErrorCallback(stdout, stderr, true);
 
         callback.error(Collections.singletonList(logEvent), new Exception("Test exception"));
 
@@ -59,7 +59,7 @@ public class SplunkErrorCallbackTest {
     @Test
     public void originalLogShouldNotBeLoggedIfConsoleHandlerEnabled() {
         InitialConfigurator.DELAYED_HANDLER.addHandler(new ConsoleHandler());
-        SplunkErrorCallback callback = new SplunkErrorCallback(stdout, stderr);
+        SplunkErrorCallback callback = new SplunkErrorCallback(stdout, stderr, true);
 
         callback.error(Collections.singletonList(logEvent), new Exception("Test exception"));
 
@@ -71,7 +71,7 @@ public class SplunkErrorCallbackTest {
         Handler handler = new ConsoleHandler();
         handler.setLevel(Level.OFF);
         InitialConfigurator.DELAYED_HANDLER.addHandler(handler);
-        SplunkErrorCallback callback = new SplunkErrorCallback(stdout, stderr);
+        SplunkErrorCallback callback = new SplunkErrorCallback(stdout, stderr, true);
 
         callback.error(Collections.singletonList(logEvent), new Exception("Test exception"));
 
@@ -80,10 +80,19 @@ public class SplunkErrorCallbackTest {
 
     @Test
     public void originalLogShouldBeLoggedToStdoutIfConsoleHandlerDisabled() {
-        SplunkErrorCallback callback = new SplunkErrorCallback(stdout, stderr);
+        SplunkErrorCallback callback = new SplunkErrorCallback(stdout, stderr, true);
 
         callback.error(Collections.singletonList(logEvent), new Exception("Test exception"));
 
         verify(stdout).println("Hello");
+    }
+
+    @Test
+    public void originalLogShouldNotBePrintedToStdoutWhenLog() {
+        SplunkErrorCallback callback = new SplunkErrorCallback(stdout, stderr, false);
+
+        callback.error(Collections.singletonList(logEvent), new Exception("Test exception"));
+
+        verify(stdout, org.mockito.Mockito.never()).println("Hello");
     }
 }


### PR DESCRIPTION
Introduces a new configuration option to disable the printing of log events to stdout when a communication error with splunk occurs. 

This is useful in scenarios where applications manages sensitive data such as PCI, PII or security token.

Also fix issue build by adding a asciidoctorj-diagram-plantuml dependency due to asciidoctorj-diagram to 3.0.1