### PR TITLE
ci: release 6.0.0, align with Quarkus 3.33 LTS

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,6 +1,6 @@
 name: Quarkiverse Extension
 release:
-  current-version: 6.0.0-alpha.1
-  next-version: 6.0.0-alpha-SNAPSHOT
+  current-version: 6.0.0
+  next-version: 6.0.0-SNAPSHOT
   additional-notes: |
-    Requires Quarkus >= 3.31 LTS and Java >= 21
+    Requires Quarkus >= 3.33 LTS and Java >= 21

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <maven.compiler.target>21</maven.compiler.target>
     <maven.compiler.release>21</maven.compiler.release>
     <maven.compiler.parameters>true</maven.compiler.parameters>
-    <quarkus.version>3.31.2</quarkus.version>
+    <quarkus.version>3.33.1.1</quarkus.version>
     <splunk.logging.version>1.11.10</splunk.logging.version>
     <!-- https://antoniogoncalves.org/2012/12/13/lets-turn-integration-tests-with-maven-to-a-first-class-citizen/ -->
     <skipTests>false</skipTests>


### PR DESCRIPTION
It contains the 1st patch of Splunk Java client in 3 years.