### PR TITLE
ci: exclude splunk repo from Maven Google mirror

### DIFF
--- a/.github/quarkus-ecosystem-maven-settings.xml
+++ b/.github/quarkus-ecosystem-maven-settings.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings>
+  <mirrors>
+    <mirror>
+      <id>google-maven-central-mirror</id>
+      <name>Google Maven Central Mirror</name>
+      <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+      <!-- Splunk artifacts are not available in Maven central -->
+      <mirrorOf>external:*,!splunk</mirrorOf>
+    </mirror>
+  </mirrors>
+  <profiles>
+    <profile>
+      <id>google-mirror</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <repositories>
+        <repository>
+          <id>google-maven-central</id>
+          <name>GCS Maven Central mirror EU</name>
+          <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>google-maven-central</id>
+          <name>GCS Maven Central mirror EU</name>
+          <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+</settings>


### PR DESCRIPTION
Due to the changes in https://github.com/quarkusio/quarkus-ecosystem-ci/pull/226, the nightly CI of the main branch with Quarkus snapshot was broken.

We have to overide the default settings with our own, it is used here: https://github.com/quarkusio/quarkus-ecosystem-ci/blob/6d23372bcc8e94d6f458a585c8d792dbcdbf3809/setup-and-test#L115-L120

The splunk repo is declared here: https://github.com/quarkiverse/quarkus-logging-splunk/blob/e403f81ffdb5c3df549e4452e78ca853a3a1e82e/pom.xml#L66-L73