### PR TITLE
Support encoding exceptions as a JSON string

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-logging-splunk.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-logging-splunk.adoc
@@ -334,6 +334,27 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
+a| [[quarkus-logging-splunk_quarkus-log-handler-splunk-exception-encoding]] [.property-path]##link:#quarkus-logging-splunk_quarkus-log-handler-splunk-exception-encoding[`+++quarkus.log.handler.splunk.exception-encoding+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.log.handler.splunk.exception-encoding+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The format used to encode exceptions in log events.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_HANDLER_SPLUNK_EXCEPTION_ENCODING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LOG_HANDLER_SPLUNK_EXCEPTION_ENCODING+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`message-only`, `json`
+|`+++message-only+++`
+
 a| [[quarkus-logging-splunk_quarkus-log-handler-splunk-include-logger-name]] [.property-path]##link:#quarkus-logging-splunk_quarkus-log-handler-splunk-include-logger-name[`+++quarkus.log.handler.splunk.include-logger-name+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.log.handler.splunk.include-logger-name+++[]
@@ -1044,6 +1065,27 @@ endif::add-copy-button-to-env-var[]
 --
 |boolean
 |`+++false+++`
+
+a| [[quarkus-logging-splunk_quarkus-log-handler-splunk-handler-name-exception-encoding]] [.property-path]##link:#quarkus-logging-splunk_quarkus-log-handler-splunk-handler-name-exception-encoding[`+++quarkus.log.handler.splunk."handler-name".exception-encoding+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.log.handler.splunk."handler-name".exception-encoding+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The format used to encode exceptions in log events.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_HANDLER_SPLUNK__HANDLER_NAME__EXCEPTION_ENCODING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LOG_HANDLER_SPLUNK__HANDLER_NAME__EXCEPTION_ENCODING+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`message-only`, `json`
+|`+++message-only+++`
 
 a| [[quarkus-logging-splunk_quarkus-log-handler-splunk-handler-name-include-logger-name]] [.property-path]##link:#quarkus-logging-splunk_quarkus-log-handler-splunk-handler-name-include-logger-name[`+++quarkus.log.handler.splunk."handler-name".include-logger-name+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-logging-splunk_quarkus.log.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-logging-splunk_quarkus.log.adoc
@@ -334,6 +334,27 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
+a| [[quarkus-logging-splunk_quarkus-log-handler-splunk-exception-encoding]] [.property-path]##link:#quarkus-logging-splunk_quarkus-log-handler-splunk-exception-encoding[`+++quarkus.log.handler.splunk.exception-encoding+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.log.handler.splunk.exception-encoding+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The format used to encode exceptions in log events.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_HANDLER_SPLUNK_EXCEPTION_ENCODING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LOG_HANDLER_SPLUNK_EXCEPTION_ENCODING+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`message-only`, `json`
+|`+++message-only+++`
+
 a| [[quarkus-logging-splunk_quarkus-log-handler-splunk-include-logger-name]] [.property-path]##link:#quarkus-logging-splunk_quarkus-log-handler-splunk-include-logger-name[`+++quarkus.log.handler.splunk.include-logger-name+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.log.handler.splunk.include-logger-name+++[]
@@ -1044,6 +1065,27 @@ endif::add-copy-button-to-env-var[]
 --
 |boolean
 |`+++false+++`
+
+a| [[quarkus-logging-splunk_quarkus-log-handler-splunk-handler-name-exception-encoding]] [.property-path]##link:#quarkus-logging-splunk_quarkus-log-handler-splunk-handler-name-exception-encoding[`+++quarkus.log.handler.splunk."handler-name".exception-encoding+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.log.handler.splunk."handler-name".exception-encoding+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The format used to encode exceptions in log events.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_HANDLER_SPLUNK__HANDLER_NAME__EXCEPTION_ENCODING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LOG_HANDLER_SPLUNK__HANDLER_NAME__EXCEPTION_ENCODING+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`message-only`, `json`
+|`+++message-only+++`
 
 a| [[quarkus-logging-splunk_quarkus-log-handler-splunk-handler-name-include-logger-name]] [.property-path]##link:#quarkus-logging-splunk_quarkus-log-handler-splunk-handler-name-include-logger-name[`+++quarkus.log.handler.splunk."handler-name".include-logger-name+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkHandlerConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkHandlerConfig.java
@@ -130,9 +130,17 @@ public interface SplunkHandlerConfig {
      * Whether to send the thrown exception message as a structured metadata of the log event (as opposed to %e in a formatted
      * message, it does not include the exception name or stacktrace).
      * Only applicable to 'nested' serialization.
+     *
+     * @see #exceptionEncoding() for different ways the exception can be encoded in the log event
      */
     @WithDefault("false")
     boolean includeException();
+
+    /**
+     * The format used to encode exceptions in log events.
+     */
+    @WithDefault("message-only")
+    ExceptionEncoding exceptionEncoding();
 
     /**
      * Whether to send the logger name as a structured metadata of the log event (equivalent of %c in a formatted message).
@@ -260,6 +268,35 @@ public interface SplunkHandlerConfig {
         RAW,
         NESTED,
         FLAT
+    }
+
+    enum ExceptionEncoding {
+        /**
+         * Encode the exception as a single string containing its message.
+         */
+        MESSAGE_ONLY,
+        /**
+         * Encode the exception as a JSON string, containing the following fields:
+         * <dl>
+         * <dt>{@code detailMessage}</dt>
+         * <dd>The message of the exception.</dd>
+         *
+         * <dt>{@code exceptionClass}</dt>
+         * <dd>The class of the exception</dd>
+         *
+         * <dt>{@code fileName}</dt>
+         * <dd>The name of the source file the exception was thrown in. Only present if the exception has a stacktrace
+         * attached.</dd>
+         *
+         * <dt>{@code methodName}</dt>
+         * <dd>The name of the method the exception was thrown in. Only present if the exception has a stracktrace
+         * attached.</dd>
+         *
+         * <dt>{@code lineNumber}</dt>
+         * <dd>The line the exception was thrown on. Only present if the exception has a stacktrace attached.</dd>
+         * </dl>
+         */
+        JSON,
     }
 
     /**

--- a/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkLogHandler.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkLogHandler.java
@@ -4,16 +4,21 @@ Contributor(s): Kevin Viet, Romain Quinio (Amadeus s.a.s.)
  */
 package io.quarkiverse.logging.splunk;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.logging.ErrorManager;
 import java.util.logging.Filter;
 import java.util.logging.Formatter;
+
+import jakarta.annotation.Nonnull;
 
 import org.jboss.logmanager.ExtHandler;
 import org.jboss.logmanager.ExtLogRecord;
 import org.jboss.logmanager.filters.AllFilter;
 
+import com.google.gson.Gson;
 import com.splunk.logging.HttpEventCollectorResendMiddleware;
 import com.splunk.logging.HttpEventCollectorSender;
 
@@ -23,16 +28,20 @@ public class SplunkLogHandler extends ExtHandler {
 
     private final boolean includeException;
 
+    private final SplunkHandlerConfig.ExceptionEncoding exceptionEncoding;
+
     private final boolean includeLoggerName;
 
     private final boolean includeThreadName;
 
-    public SplunkLogHandler(HttpEventCollectorSender sender, boolean includeException, boolean includeLoggerName,
+    public SplunkLogHandler(HttpEventCollectorSender sender, boolean includeException,
+            SplunkHandlerConfig.ExceptionEncoding exceptionEncoding, boolean includeLoggerName,
             boolean includeThreadName, boolean disableCertificateValidation, long retriesOnError) {
         this.sender = sender;
         this.includeException = includeException;
         this.includeLoggerName = includeLoggerName;
         this.includeThreadName = includeThreadName;
+        this.exceptionEncoding = exceptionEncoding;
 
         if (disableCertificateValidation) {
             this.sender.disableCertificateValidation();
@@ -56,8 +65,15 @@ public class SplunkLogHandler extends ExtHandler {
                 includeLoggerName ? record.getLoggerName() : null,
                 includeThreadName ? String.format(Locale.US, "%d", record.getThreadID()) : null,
                 record.getMdcCopy(),
-                (!includeException || record.getThrown() == null) ? null : record.getThrown().getMessage(),
+                (!includeException || record.getThrown() == null) ? null : encodeException(record.getThrown()),
                 null);
+    }
+
+    private String encodeException(@Nonnull Throwable thrown) {
+        return switch (this.exceptionEncoding) {
+            case MESSAGE_ONLY -> thrown.getMessage();
+            case JSON -> generateErrorDetail(thrown);
+        };
     }
 
     /**
@@ -96,5 +112,39 @@ public class SplunkLogHandler extends ExtHandler {
         } else {
             super.setFilter(newFilter);
         }
+    }
+
+    /**
+     * Method used to generate proper exception message if any exception encountered.
+     *
+     * @param throwable the exception in the event
+     * @return the processed string of all exception detail
+     */
+    private String generateErrorDetail(final Throwable throwable) {
+        String exceptionDetail = "";
+
+        /*
+         * Exception details are only populated when any ERROR OR FATAL event occurred
+         */
+        try {
+            // Exception thrown in application is wrapped with relevant information instead of just a message.
+            Map<String, String> exceptionDetailMap = new LinkedHashMap<>();
+
+            exceptionDetailMap.put("detailMessage", throwable.getMessage());
+            exceptionDetailMap.put("exceptionClass", throwable.getClass().toString());
+
+            StackTraceElement[] elements = throwable.getStackTrace();
+            // Retrieving first element from elements array is because the throws exception detail would be available as a first element.
+            if (elements != null && elements.length > 0 && elements[0] != null) {
+                exceptionDetailMap.put("fileName", elements[0].getFileName());
+                exceptionDetailMap.put("methodName", elements[0].getMethodName());
+                exceptionDetailMap.put("lineNumber", String.valueOf(elements[0].getLineNumber()));
+            }
+            exceptionDetail = new Gson().toJson(exceptionDetailMap);
+        } catch (Exception e) {
+            // No action here
+        }
+
+        return exceptionDetail;
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkLogHandlerRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/splunk/SplunkLogHandlerRecorder.java
@@ -156,6 +156,7 @@ public class SplunkLogHandlerRecorder {
             SplunkHandlerConfig config) {
         return new SplunkLogHandler(sender,
                 config.includeException(),
+                config.exceptionEncoding(),
                 config.includeLoggerName(),
                 config.includeThreadName(),
                 config.disableCertificateValidation(),

--- a/runtime/src/test/java/io/quarkiverse/logging/splunk/SplunkLogHandlerTest.java
+++ b/runtime/src/test/java/io/quarkiverse/logging/splunk/SplunkLogHandlerTest.java
@@ -4,14 +4,20 @@ Contributor(s): Kevin Viet, Romain Quinio (Amadeus s.a.s.)
  */
 package io.quarkiverse.logging.splunk;
 
+import static io.quarkiverse.logging.splunk.SplunkHandlerConfig.ExceptionEncoding.JSON;
+import static io.quarkiverse.logging.splunk.SplunkHandlerConfig.ExceptionEncoding.MESSAGE_ONLY;
+import static java.util.Map.entry;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import java.io.Serializable;
+import java.util.Map;
 import java.util.logging.Formatter;
 import java.util.logging.Level;
 
@@ -19,10 +25,15 @@ import org.jboss.logmanager.ExtLogRecord;
 import org.jboss.logmanager.formatters.PatternFormatter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
 import org.mockito.Spy;
+import org.mockito.internal.matchers.ContainsExtraTypeInfo;
+import org.mockito.internal.matchers.text.ValuePrinter;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 import com.splunk.logging.HttpEventCollectorResendMiddleware;
 import com.splunk.logging.HttpEventCollectorSender;
 
@@ -37,14 +48,14 @@ class SplunkLogHandlerTest {
 
     @Test
     void handlerShouldSetSenderOptions() {
-        SplunkLogHandler handler = new SplunkLogHandler(sender, true, true, true, true, 1);
+        SplunkLogHandler handler = new SplunkLogHandler(sender, true, MESSAGE_ONLY, true, true, true, 1);
         verify(sender).disableCertificateValidation();
         verify(sender).addMiddleware(isA(HttpEventCollectorResendMiddleware.class));
     }
 
     @Test
     void handlerShouldFormatMessages() {
-        SplunkLogHandler handler = new SplunkLogHandler(sender, true, true, true, true, 1);
+        SplunkLogHandler handler = new SplunkLogHandler(sender, true, MESSAGE_ONLY, true, true, true, 1);
         handler.setFormatter(formatter);
         ExtLogRecord record = new ExtLogRecord(Level.ALL, "Hello {0}", SplunkLogHandlerTest.class.getName());
         record.setParameters(new String[] { "world" });
@@ -64,7 +75,7 @@ class SplunkLogHandlerTest {
 
     @Test
     void shouldSendRecordUsingHec() {
-        SplunkLogHandler handler = new SplunkLogHandler(sender, true, true, true, true, 1);
+        SplunkLogHandler handler = new SplunkLogHandler(sender, true, MESSAGE_ONLY, true, true, true, 1);
         handler.setFormatter(formatter);
         ExtLogRecord record = new ExtLogRecord(Level.ALL, "Log Message", SplunkLogHandlerTest.class.getName());
         record.setLoggerName("Logger");
@@ -84,8 +95,29 @@ class SplunkLogHandlerTest {
     }
 
     @Test
+    void shouldEncodeExceptionsAsJsonWhenConfigured() throws Exception {
+        SplunkLogHandler handler = new SplunkLogHandler(sender, true, JSON, true, true, true, 1);
+        handler.setFormatter(formatter);
+        ExtLogRecord record = new ExtLogRecord(Level.ALL, "Log Message", SplunkLogHandlerTest.class.getName());
+        record.setLoggerName("Logger");
+        record.setThreadID(1);
+        record.setThrown(new RuntimeException("Exception occurred"));
+
+        handler.publish(record);
+
+        verify(sender).send(anyLong(),
+                eq(record.getLevel().toString()),
+                eq(record.getMessage()),
+                eq(record.getLoggerName()),
+                eq("1"),
+                anyMap(),
+                argThat(new ExceptionJsonMatcher(record.getThrown())),
+                isNull());
+    }
+
+    @Test
     void handlerShouldFlushHec() {
-        SplunkLogHandler handler = new SplunkLogHandler(sender, true, false, false, false, 0);
+        SplunkLogHandler handler = new SplunkLogHandler(sender, true, MESSAGE_ONLY, false, false, false, 0);
         handler.flush();
         verify(sender).flush();
         verifyNoMoreInteractions(sender);
@@ -93,10 +125,51 @@ class SplunkLogHandlerTest {
 
     @Test
     void handlerShouldCloseHecProperly() {
-        SplunkLogHandler handler = new SplunkLogHandler(sender, true, false, false, false, 0);
+        SplunkLogHandler handler = new SplunkLogHandler(sender, true, MESSAGE_ONLY, false, false, false, 0);
         handler.close();
         verify(sender).flush(eq(true));
         verify(sender).cancel();
         verifyNoMoreInteractions(sender);
+    }
+
+    private static class ExceptionJsonMatcher implements ArgumentMatcher<String>, ContainsExtraTypeInfo {
+        private Map<String, ? extends Serializable> wanted;
+
+        public ExceptionJsonMatcher(Throwable throwable) {
+            wanted = Map.ofEntries(
+                    Map.entry("detailMessage", throwable.getMessage()),
+                    Map.entry("exceptionClass", throwable.getClass().toString()),
+                    Map.entry("fileName", throwable.getStackTrace()[0].getFileName()),
+                    Map.entry("methodName", throwable.getStackTrace()[0].getMethodName()),
+                    Map.entry("lineNumber", String.valueOf(throwable.getStackTrace()[0].getLineNumber())));
+        }
+
+        @Override
+        public String toString() {
+            return ValuePrinter.print(wanted);
+        }
+
+        @Override
+        public boolean matches(String json) {
+            Map<String, String> exceptionFields = new Gson().fromJson(json, new TypeToken<>() {
+            });
+
+            return wanted.equals(exceptionFields);
+        }
+
+        @Override
+        public String toStringWithType(String className) {
+            return "";
+        }
+
+        @Override
+        public boolean typeMatches(Object target) {
+            return false;
+        }
+
+        @Override
+        public Object getWanted() {
+            return wanted;
+        }
     }
 }


### PR DESCRIPTION
I ported the implementation of JSON-encoding the exception from the upstream splunk-library-javalogging.

Users can opt into this by setting a property, meaning that, by default, they get the current behavior: only the exception's message is included.

fixes: #424